### PR TITLE
bug: 구글 계정이 없는 휴대폰 안내 및 api28에서 사진 저장 권한 처리

### DIFF
--- a/app/src/main/java/com/conkeep/data/auth/SupabaseAuthManager.kt
+++ b/app/src/main/java/com/conkeep/data/auth/SupabaseAuthManager.kt
@@ -1,6 +1,10 @@
 package com.conkeep.data.auth
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.provider.Settings
+import android.util.Log
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import com.conkeep.BuildConfig
@@ -75,6 +79,7 @@ class SupabaseAuthManager
                         .Builder()
                         .setFilterByAuthorizedAccounts(false) // 모든 계정 표시
                         .setServerClientId(BuildConfig.WEB_CLIENT_ID)
+                        .setAutoSelectEnabled(true)
                         .build()
 
                 val request =
@@ -105,10 +110,38 @@ class SupabaseAuthManager
                         ?: throw Exception("로그인 후 사용자 정보를 가져오지 못했습니다.")
 
                 Result.success(user)
+            } catch (e: androidx.credentials.exceptions.NoCredentialException) {
+                promptAddGoogleAccount(activity)
+                Result.failure(NoGoogleAccountException("구글 계정을 먼저 추가해주세요"))
+            } catch (e: androidx.credentials.exceptions.GetCredentialCancellationException) {
+                Result.failure(e)
             } catch (e: Exception) {
-                // 사용자가 취소한 경우 등에 대한 예외 처리 필요
+                Log.e("SupabaseAuth", "Google 로그인 실패", e)
                 Result.failure(e)
             }
+
+        /**
+         * 구글 계정 추가 화면 열기
+         */
+        private fun promptAddGoogleAccount(activity: Activity) {
+            try {
+                val intent =
+                    Intent(Settings.ACTION_ADD_ACCOUNT).apply {
+                        // 구글 계정만 표시
+                        putExtra(Settings.EXTRA_ACCOUNT_TYPES, arrayOf("com.google"))
+                    }
+                activity.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                // 일부 기기에서 ACTION_ADD_ACCOUNT를 지원하지 않을 수 있음
+                Log.e("SupabaseAuth", "계정 추가 화면을 열 수 없습니다", e)
+                // 폴백: 동기화 설정 화면
+                try {
+                    activity.startActivity(Intent(Settings.ACTION_SYNC_SETTINGS))
+                } catch (e2: Exception) {
+                    Log.e("SupabaseAuth", "설정 화면을 열 수 없습니다", e2)
+                }
+            }
+        }
 
         suspend fun signOut() {
             auth.signOut()
@@ -122,3 +155,7 @@ class SupabaseAuthManager
             }
         }
     }
+
+class NoGoogleAccountException(
+    message: String,
+) : Exception(message)

--- a/app/src/main/java/com/conkeep/ui/feature/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/auth/AuthViewModel.kt
@@ -27,7 +27,7 @@ class AuthViewModel
                     .onSuccess { user ->
                         Toast.makeText(activity, "${user.email} 로그인 성공", Toast.LENGTH_SHORT).show()
                     }.onFailure { error ->
-                        Toast.makeText(activity, "${error.message} 로그인 실패", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(activity, "${error.message}", Toast.LENGTH_SHORT).show()
                     }
             }
         }

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/image/CouponImageScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/image/CouponImageScreen.kt
@@ -1,8 +1,13 @@
 package com.conkeep.ui.feature.coupon.image
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -22,6 +27,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -55,6 +62,59 @@ fun CouponImageScreen(
     val saveSuccessMsg = stringResource(R.string.coupon_image_saved)
     val saveFailMsg = stringResource(R.string.coupon_image_save_failed)
     val shareFailMsg = stringResource(R.string.coupon_image_processing_failed)
+    val filePermissionMsg = stringResource(R.string.coupon_image_save_permission_not_grant)
+
+    fun executeSave() {
+        viewModel.saveCoupon { success ->
+            Toast
+                .makeText(
+                    context,
+                    if (success == true) saveSuccessMsg else saveFailMsg,
+                    Toast.LENGTH_SHORT,
+                ).show()
+        }
+    }
+
+    fun checkPermission(): Boolean =
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { isGranted ->
+            when (isGranted) {
+                true -> {
+                    executeSave()
+                }
+
+                false -> {
+                    val activity = context as? Activity
+                    if (activity != null) {
+                        val shouldShowRationale =
+                            ActivityCompat.shouldShowRequestPermissionRationale(
+                                activity,
+                                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                            )
+                        if (!shouldShowRationale) {
+                            // Todo: 영구 거부 - 설정으로 이동 스낵바 버튼 추가
+                            Toast
+                                .makeText(
+                                    context,
+                                    filePermissionMsg,
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                        }
+                    }
+                }
+            }
+        }
 
     if (window != null) {
         val controller =
@@ -82,22 +142,9 @@ fun CouponImageScreen(
             }
         },
         onSaveClick = {
-            viewModel.saveCoupon { success ->
-                if (success != null && success) {
-                    Toast
-                        .makeText(
-                            context,
-                            saveSuccessMsg,
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                } else {
-                    Toast
-                        .makeText(
-                            context,
-                            saveFailMsg,
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                }
+            when (checkPermission()) {
+                true -> executeSave()
+                false -> permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
             }
         },
         onShareClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="coupon_image_saved">갤러리에 쿠폰 이미지를 저장하였습니다.</string>
     <string name="coupon_image_save_failed">쿠폰 이미지 저장에 실패하였습니다.</string>
     <string name="coupon_image_processing_failed">이미지 파일 처리에 실패하였습니다.</string>
+    <string name="coupon_image_save_permission_not_grant">이미지 저장을 위해 앱 설정에서 파일 권한을 허용해주세요.</string>
 
 
 </resources>


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #33 

## 📋 작업 내용
기기에 게정이 없을경우 로그인으로 이동
안드로이드9 기기에서 쿠폰 사진 저장시 저장 권한을 받아오는 로직 추가

## 📸 참고사항 및 스크린샷
[Screen_recording_20260124_114321.webm](https://github.com/user-attachments/assets/28bdfb77-eb56-4b25-9be8-e8e27795fae9)
