### PR TITLE
bug: 쿠폰 목록에서 쿠폰 스크롤 위치가 유지되지 않음

### DIFF
--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -70,6 +69,7 @@ class CouponRepository
             sortType: Int,
         ): Flow<PagingData<Coupon>> =
             authManager.currentUserIdFlow
+                .filterNotNull()
                 .flatMapLatest { userId ->
                     Pager(
                         config =
@@ -81,7 +81,7 @@ class CouponRepository
                         initialKey = 0,
                         pagingSourceFactory = {
                             couponDao.searchCouponsPaging(
-                                userId = userId ?: "", // ID 스트림에 따라 자동 재시작
+                                userId = userId,
                                 searchQuery = query,
                                 today = today,
                                 filterType = filterType,
@@ -98,25 +98,16 @@ class CouponRepository
             today: String,
             filterType: Int,
         ): Flow<Int> =
-            authManager.currentUserIdFlow.flatMapLatest { userId ->
-                if (userId.isNullOrEmpty()) {
-                    flowOf(0) // ID가 없으면 0 반환하며 대기
-                } else {
-                    // ID가 들어오는 순간 Room 쿼리를 다시 실행
-                    couponDao.getCouponsCount(userId, query, today, filterType)
-                }
+            authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
+                couponDao.getCouponsCount(userId, query, today, filterType)
             }
 
         fun getCouponSummary(today: String): Flow<CouponCountSummary> =
-            authManager.currentUserIdFlow.flatMapLatest { userId ->
-                if (userId.isNullOrEmpty()) {
-                    flowOf(CouponCountSummary())
-                } else {
-                    couponDao.getCouponSummaryFlow(
-                        userId = userId,
-                        today = today,
-                    )
-                }
+            authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
+                couponDao.getCouponSummaryFlow(
+                    userId = userId,
+                    today = today,
+                )
             }
 
         fun getCoupon(id: String): Flow<Coupon?> =

--- a/app/src/main/res/drawable/ic_more.xml
+++ b/app/src/main/res/drawable/ic_more.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11,12C11,12.552 11.448,13 12,13C12.552,13 13,12.552 13,12C13,11.448 12.552,11 12,11C11.448,11 11,11.448 11,12Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#002147"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18,12C18,12.552 18.448,13 19,13C19.552,13 20,12.552 20,12C20,11.448 19.552,11 19,11C18.448,11 18,11.448 18,12Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#002147"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M4,12C4,12.552 4.448,13 5,13C5.552,13 6,12.552 6,12C6,11.448 5.552,11 5,11C4.448,11 4,11.448 4,12Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#002147"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #42 

## 📋 원인
슈파베이스 라이브러리가 앱 상태 변화(백그라운드/포그라운드) 시 세션을 재검증하는 과정에 잠시 null 값을 Flow 로 방출
이 Flow를 구독하던 Repository의 flatMapLatest가 동작하여 데이터 스트림을 초기화
LazyColumn은 아이템이 0개가 되는 순간 유지하던 스크롤 위치를 버리고 0번(최상단)으로 리셋.
세션이 다시 잡히며 데이터(6개)가 돌아오지만, 스크롤은 초기화됨

리포지토리에서 .filterNotNull()를 통해 id 가 null로 들어오는 플로우를 무시하여 해결

## 📸 참고사항 및 스크린샷
