### PR TITLE
feat: 쿠폰 분석 처리 과정 로직 변경

### DIFF
--- a/app/schemas/com.conkeep.data.local.CouponDatabase/4.json
+++ b/app/schemas/com.conkeep.data.local.CouponDatabase/4.json
@@ -1,0 +1,137 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "5da6b62ca1f89d1db4bf53e621e872de",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `remote_id` TEXT, `user_id` TEXT NOT NULL, `image_url` TEXT, `image_key` TEXT, `thumbnail_url` TEXT, `local_image_path` TEXT, `product_name` TEXT, `brand` TEXT, `coupon_pin` TEXT, `expiry_date` TEXT, `is_monetary` INTEGER NOT NULL, `amount` INTEGER, `category` TEXT, `user_memo` TEXT, `is_used` INTEGER NOT NULL, `used_at` INTEGER, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `local_status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageKey",
+            "columnName": "image_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "local_image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couponPin",
+            "columnName": "coupon_pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiry_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isMonetary",
+            "columnName": "is_monetary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMemo",
+            "columnName": "user_memo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isUsed",
+            "columnName": "is_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "local_status",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5da6b62ca1f89d1db4bf53e621e872de')"
+    ]
+  }
+}

--- a/app/schemas/com.conkeep.data.local.CouponDatabase/5.json
+++ b/app/schemas/com.conkeep.data.local.CouponDatabase/5.json
@@ -1,0 +1,183 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "b27ef36c2c1b721f429c1e0e131de5f0",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `remote_id` TEXT, `user_id` TEXT NOT NULL, `image_url` TEXT, `image_key` TEXT, `thumbnail_url` TEXT, `local_image_path` TEXT, `product_name` TEXT, `brand` TEXT, `coupon_pin` TEXT, `expiry_date` TEXT, `is_monetary` INTEGER NOT NULL, `amount` INTEGER, `category` TEXT, `user_memo` TEXT, `is_used` INTEGER NOT NULL, `used_at` INTEGER, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `local_status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageKey",
+            "columnName": "image_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "local_image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couponPin",
+            "columnName": "coupon_pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiry_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isMonetary",
+            "columnName": "is_monetary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMemo",
+            "columnName": "user_memo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isUsed",
+            "columnName": "is_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "local_status",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_coupons_user_id_is_used_created_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_created_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `created_at`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_expiry_date",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "expiry_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_expiry_date` ON `${TABLE_NAME}` (`user_id`, `is_used`, `expiry_date`)"
+          },
+          {
+            "name": "index_coupons_user_id_expiry_date_is_used",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "expiry_date",
+              "is_used"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_expiry_date_is_used` ON `${TABLE_NAME}` (`user_id`, `expiry_date`, `is_used`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_used_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "used_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_used_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `used_at`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b27ef36c2c1b721f429c1e0e131de5f0')"
+    ]
+  }
+}

--- a/app/schemas/com.conkeep.data.local.CouponDatabase/6.json
+++ b/app/schemas/com.conkeep.data.local.CouponDatabase/6.json
@@ -1,0 +1,178 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "448207d92b064fcb8ab071aa93206b7a",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `image_url` TEXT, `image_key` TEXT, `thumbnail_url` TEXT, `local_image_path` TEXT, `product_name` TEXT, `brand` TEXT, `coupon_pin` TEXT, `expiry_date` TEXT, `is_monetary` INTEGER NOT NULL, `amount` INTEGER, `category` TEXT, `user_memo` TEXT, `is_used` INTEGER NOT NULL, `used_at` INTEGER, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageKey",
+            "columnName": "image_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "local_image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couponPin",
+            "columnName": "coupon_pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiry_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isMonetary",
+            "columnName": "is_monetary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMemo",
+            "columnName": "user_memo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isUsed",
+            "columnName": "is_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_coupons_user_id_is_used_created_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_created_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `created_at`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_expiry_date",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "expiry_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_expiry_date` ON `${TABLE_NAME}` (`user_id`, `is_used`, `expiry_date`)"
+          },
+          {
+            "name": "index_coupons_user_id_expiry_date_is_used",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "expiry_date",
+              "is_used"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_expiry_date_is_used` ON `${TABLE_NAME}` (`user_id`, `expiry_date`, `is_used`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_used_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "used_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_used_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `used_at`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '448207d92b064fcb8ab071aa93206b7a')"
+    ]
+  }
+}

--- a/app/schemas/com.conkeep.data.local.CouponDatabase/7.json
+++ b/app/schemas/com.conkeep.data.local.CouponDatabase/7.json
@@ -1,0 +1,178 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "448207d92b064fcb8ab071aa93206b7a",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `image_url` TEXT, `image_key` TEXT, `thumbnail_url` TEXT, `local_image_path` TEXT, `product_name` TEXT, `brand` TEXT, `coupon_pin` TEXT, `expiry_date` TEXT, `is_monetary` INTEGER NOT NULL, `amount` INTEGER, `category` TEXT, `user_memo` TEXT, `is_used` INTEGER NOT NULL, `used_at` INTEGER, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageKey",
+            "columnName": "image_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "local_image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couponPin",
+            "columnName": "coupon_pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiry_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isMonetary",
+            "columnName": "is_monetary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMemo",
+            "columnName": "user_memo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isUsed",
+            "columnName": "is_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_coupons_user_id_is_used_created_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_created_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `created_at`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_expiry_date",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "expiry_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_expiry_date` ON `${TABLE_NAME}` (`user_id`, `is_used`, `expiry_date`)"
+          },
+          {
+            "name": "index_coupons_user_id_expiry_date_is_used",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "expiry_date",
+              "is_used"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_expiry_date_is_used` ON `${TABLE_NAME}` (`user_id`, `expiry_date`, `is_used`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_used_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "used_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_used_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `used_at`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '448207d92b064fcb8ab071aa93206b7a')"
+    ]
+  }
+}

--- a/app/schemas/com.conkeep.data.local.CouponDatabase/8.json
+++ b/app/schemas/com.conkeep.data.local.CouponDatabase/8.json
@@ -1,0 +1,190 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "5ba76051854241cac720ece691266424",
+    "entities": [
+      {
+        "tableName": "coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `image_url` TEXT, `image_key` TEXT, `thumbnail_url` TEXT, `local_image_path` TEXT, `product_name` TEXT, `brand` TEXT, `coupon_pin` TEXT, `expiry_date` TEXT, `is_monetary` INTEGER NOT NULL, `amount` INTEGER, `category` TEXT, `user_memo` TEXT, `is_used` INTEGER NOT NULL, `used_at` INTEGER, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `status` TEXT, `is_dirty` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageKey",
+            "columnName": "image_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "local_image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couponPin",
+            "columnName": "coupon_pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expiryDate",
+            "columnName": "expiry_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isMonetary",
+            "columnName": "is_monetary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMemo",
+            "columnName": "user_memo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isUsed",
+            "columnName": "is_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDirty",
+            "columnName": "is_dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_coupons_user_id_is_used_created_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_created_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `created_at`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_expiry_date",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "expiry_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_expiry_date` ON `${TABLE_NAME}` (`user_id`, `is_used`, `expiry_date`)"
+          },
+          {
+            "name": "index_coupons_user_id_expiry_date_is_used",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "expiry_date",
+              "is_used"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_expiry_date_is_used` ON `${TABLE_NAME}` (`user_id`, `expiry_date`, `is_used`)"
+          },
+          {
+            "name": "index_coupons_user_id_is_used_used_at",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "is_used",
+              "used_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_coupons_user_id_is_used_used_at` ON `${TABLE_NAME}` (`user_id`, `is_used`, `used_at`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5ba76051854241cac720ece691266424')"
+    ]
+  }
+}

--- a/app/src/main/java/com/conkeep/data/local/CouponDatabase.kt
+++ b/app/src/main/java/com/conkeep/data/local/CouponDatabase.kt
@@ -2,9 +2,12 @@ package com.conkeep.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.conkeep.data.local.dao.CouponDao
 import com.conkeep.data.local.entity.CouponEntity
+import com.conkeep.data.remote.dto.CouponTypeConverters
 
+@TypeConverters(CouponTypeConverters::class)
 @Database(
     entities = [CouponEntity::class],
     version = 8,

--- a/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
+++ b/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
@@ -11,6 +11,7 @@ import com.conkeep.data.local.dto.CouponCountResult
 import com.conkeep.data.local.entity.CouponEntity
 import com.conkeep.ui.feature.coupon.model.CouponCountSummary
 import com.conkeep.ui.feature.coupon.model.CouponFilterType
+import com.conkeep.ui.feature.coupon.model.CouponSortType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -76,7 +77,7 @@ interface CouponDao {
         searchQuery: String,
         today: String,
         filterType: Int,
-        sortType: Int,
+        sortType: CouponSortType,
     ): PagingSource<Int, CouponEntity>
 
     /**
@@ -167,35 +168,11 @@ interface CouponDao {
         imageKey: String,
     )
 
-    @Query(
-        """
-    UPDATE OR IGNORE coupons 
-    SET 
-        product_name = COALESCE(:productName, product_name),
-        brand = COALESCE(:brand, brand),
-        coupon_pin = COALESCE(:couponPin, coupon_pin),
-        expiry_date = COALESCE(:expiryDate, expiry_date),
-        is_monetary = COALESCE(:isMonetary, is_monetary),
-        amount = COALESCE(:amount, amount),
-        category = COALESCE(:category, category),
-        status = COALESCE(:status, status),
-        
-        updated_at = :updatedAt
-    WHERE id = :couponId
-""",
+    @Query("UPDATE coupons SET status = :couponStatus WHERE id = :id")
+    suspend fun updateStatus(
+        id: String,
+        couponStatus: String,
     )
-    suspend fun updateAiRecognitionInfo(
-        couponId: String,
-        productName: String?,
-        brand: String?,
-        couponPin: String?,
-        expiryDate: String?,
-        isMonetary: Boolean?,
-        amount: Int?,
-        category: String?,
-        status: String?,
-        updatedAt: Long,
-    ): Int
 
     @Query("UPDATE coupons SET is_used = 1, used_at = :usedAt WHERE id = :id")
     suspend fun markAsUsed(

--- a/app/src/main/java/com/conkeep/data/local/entity/CouponEntity.kt
+++ b/app/src/main/java/com/conkeep/data/local/entity/CouponEntity.kt
@@ -68,5 +68,5 @@ data class CouponEntity(
     @ColumnInfo(name = "is_dirty")
     val isDirty: Boolean = false,
     @ColumnInfo(name = "is_deleted")
-    val isDeleted: Boolean = false
+    val isDeleted: Boolean = false,
 )

--- a/app/src/main/java/com/conkeep/data/local/entity/CouponStatus.kt
+++ b/app/src/main/java/com/conkeep/data/local/entity/CouponStatus.kt
@@ -17,5 +17,5 @@ enum class CouponStatus {
     AI_FAILED,
 
     /** 6. 업로드 실패: 네트워크 문제 등으로 R2 업로드 자체가 실패함 */
-    UPLOAD_FAILED
+    UPLOAD_FAILED,
 }

--- a/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
+++ b/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
@@ -28,13 +28,18 @@ fun CouponEntity.toDomain(): Coupon =
         // Long → LocalDateTime
         usedAt =
             usedAt?.let { epochMilli ->
-                Instant.fromEpochMilliseconds(epochMilli)
+                Instant
+                    .fromEpochMilliseconds(epochMilli)
                     .toLocalDateTime(TimeZone.currentSystemDefault())
             },
-        createdAt = Instant.fromEpochMilliseconds(createdAt)
-            .toLocalDateTime(TimeZone.currentSystemDefault()),
-        updatedAt = Instant.fromEpochMilliseconds(updatedAt)
-            .toLocalDateTime(TimeZone.currentSystemDefault()),
+        createdAt =
+            Instant
+                .fromEpochMilliseconds(createdAt)
+                .toLocalDateTime(TimeZone.currentSystemDefault()),
+        updatedAt =
+            Instant
+                .fromEpochMilliseconds(updatedAt)
+                .toLocalDateTime(TimeZone.currentSystemDefault()),
         isSynced = isSynced,
         status = status,
     )

--- a/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
+++ b/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
@@ -1,11 +1,10 @@
 package com.conkeep.data.mapper
 
 import com.conkeep.data.local.entity.CouponEntity
+import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.domain.model.Coupon
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
+import java.time.OffsetDateTime
 import kotlin.time.Instant
 
 fun CouponEntity.toDomain(): Coupon =
@@ -30,16 +29,13 @@ fun CouponEntity.toDomain(): Coupon =
             usedAt?.let { epochMilli ->
                 Instant
                     .fromEpochMilliseconds(epochMilli)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
             },
         createdAt =
             Instant
-                .fromEpochMilliseconds(createdAt)
-                .toLocalDateTime(TimeZone.currentSystemDefault()),
+                .fromEpochMilliseconds(createdAt),
         updatedAt =
             Instant
-                .fromEpochMilliseconds(updatedAt)
-                .toLocalDateTime(TimeZone.currentSystemDefault()),
+                .fromEpochMilliseconds(updatedAt),
         isSynced = isSynced,
         status = status,
     )
@@ -63,12 +59,47 @@ fun Coupon.toEntity(): CouponEntity =
         category = category?.name,
         userMemo = userMemo,
         isUsed = isUsed,
-        // kotlinx.LocalDateTime → Long (Unix timestamp)
-        usedAt = usedAt?.toInstant(TimeZone.currentSystemDefault())?.toEpochMilliseconds(),
-        createdAt = createdAt.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds(),
-        updatedAt = updatedAt.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds(),
+        // kotlinx.Instant → Long (Unix timestamp)
+        usedAt = usedAt?.toEpochMilliseconds(),
+        createdAt = createdAt.toEpochMilliseconds(),
+        updatedAt = updatedAt.toEpochMilliseconds(),
         isSynced = isSynced,
         status = status,
     )
 
 fun List<Coupon>.toEntity(): List<CouponEntity> = map { it.toEntity() }
+
+fun CouponDto.toEntity(existingLocalPath: String? = null): CouponEntity {
+    // ISO 8601 문자열을 Long(Epoch Milli)으로 변환하는 헬퍼 함수
+    fun String?.toEpochMilli(): Long =
+        if (this.isNullOrBlank()) {
+            0L
+        } else {
+            OffsetDateTime.parse(this).toInstant().toEpochMilli()
+        }
+
+    return CouponEntity(
+        id = this.id,
+        userId = this.userId,
+        imageUrl = this.imageUrl,
+        imageKey = this.imageKey,
+        thumbnailUrl = this.thumbnailUrl,
+        localImagePath = existingLocalPath, // 로컬 경로는 보존해야 함
+        productName = this.productName,
+        brand = this.brand,
+        couponPin = this.couponPin,
+        expiryDate = this.expiryDate,
+        isMonetary = this.isMonetary,
+        amount = this.amount,
+        category = this.category,
+        userMemo = this.userMemo,
+        isUsed = this.isUsed,
+        usedAt = this.usedAt.toEpochMilli().takeIf { it > 0 },
+        createdAt = this.createdAt.toEpochMilli(),
+        updatedAt = this.updatedAt.toEpochMilli(),
+        isSynced = true, // 서버에서 받았으므로 동기화 완료
+        status = this.status,
+        isDirty = false, // 서버 데이터와 일치하므로 Dirty 해제
+        isDeleted = this.isDeleted,
+    )
+}

--- a/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeRequest.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeRequest.kt
@@ -7,4 +7,5 @@ data class AiAnalyzeRequest(
     val couponId: String,
     val imageUrl: String,
     val barcode: String? = null,
+    val createdAt: String, // "2026-02-13T11:32:27Z" 형식
 )

--- a/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeRequest.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeRequest.kt
@@ -1,0 +1,10 @@
+package com.conkeep.data.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AiAnalyzeRequest(
+    val couponId: String,
+    val imageUrl: String,
+    val barcode: String? = null,
+)

--- a/app/src/main/java/com/conkeep/data/remote/dto/AiCouponResponse.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/AiCouponResponse.kt
@@ -5,21 +5,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class AiCouponResponse(
-    val data: CouponInfo,
+    val success: Boolean,
+    val data: CouponDto,
+    @SerialName("db_status") val dbStatus: String,
+    val metadata: AiMetadata? = null,
 )
 
 @Serializable
-data class CouponInfo(
-    @SerialName("product_name")
-    val productName: String?,
-    val brand: String?,
-    @SerialName("coupon_pin")
-    val couponPin: String?,
-    @SerialName("expiry_date")
-    val expiryDate: String?,
-    val dday: Int?,
-    @SerialName("is_monetary")
-    val isMonetary: Boolean,
-    val amount: Int? = null,
-    val category: String,
+data class AiMetadata(
+    val userId: String,
+    val couponId: String,
 )

--- a/app/src/main/java/com/conkeep/data/remote/dto/CouponDTO.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/CouponDTO.kt
@@ -1,0 +1,37 @@
+package com.conkeep.data.remote.dto
+
+import androidx.room.TypeConverter
+import com.conkeep.ui.feature.coupon.model.CouponSortType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CouponDto(
+    val id: String,
+    @SerialName("user_id") val userId: String,
+    @SerialName("image_url") val imageUrl: String?,
+    @SerialName("image_key") val imageKey: String?,
+    @SerialName("thumbnail_url") val thumbnailUrl: String?,
+    @SerialName("product_name") val productName: String?,
+    val brand: String?,
+    @SerialName("coupon_pin") val couponPin: String?,
+    @SerialName("expiry_date") val expiryDate: String?, // "2026-01-14"
+    @SerialName("is_monetary") val isMonetary: Boolean,
+    val amount: Int?,
+    val category: String?,
+    @SerialName("user_memo") val userMemo: String?,
+    @SerialName("is_used") val isUsed: Boolean,
+    @SerialName("used_at") val usedAt: String?, // ISO 8601 String
+    @SerialName("created_at") val createdAt: String, // ISO 8601 String
+    @SerialName("updated_at") val updatedAt: String, // ISO 8601 String
+    val status: String,
+    @SerialName("is_deleted") val isDeleted: Boolean,
+)
+
+class CouponTypeConverters {
+    @TypeConverter
+    fun fromSortType(type: CouponSortType): Int = type.sortType
+
+    @TypeConverter
+    fun toSortType(value: Int): CouponSortType = CouponSortType.entries.find { it.sortType == value } ?: CouponSortType.RECENT_ADD
+}

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -7,12 +7,11 @@ import androidx.paging.map
 import com.conkeep.BuildConfig
 import com.conkeep.data.auth.SupabaseAuthManager
 import com.conkeep.data.local.dao.CouponDao
-import com.conkeep.data.local.entity.CouponStatus
 import com.conkeep.data.mapper.toDomain
 import com.conkeep.data.mapper.toEntity
 import com.conkeep.data.remote.dto.AiAnalyzeRequest
 import com.conkeep.data.remote.dto.AiCouponResponse
-import com.conkeep.data.remote.dto.CouponInfo
+import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.data.remote.dto.PresignedUrlResponse
 import com.conkeep.data.remote.dto.SupabaseCoupon
 import com.conkeep.data.remote.dto.toEntity
@@ -20,6 +19,7 @@ import com.conkeep.di.annotation.AuthClient
 import com.conkeep.di.annotation.R2UploadClient
 import com.conkeep.domain.model.Coupon
 import com.conkeep.ui.feature.coupon.model.CouponCountSummary
+import com.conkeep.ui.feature.coupon.model.CouponSortType
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
 import io.ktor.client.HttpClient
@@ -47,8 +47,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -67,7 +65,7 @@ class CouponRepository
             query: String,
             today: String,
             filterType: Int,
-            sortType: Int,
+            sortType: CouponSortType,
         ): Flow<PagingData<Coupon>> =
             authManager.currentUserIdFlow
                 .filterNotNull()
@@ -121,57 +119,6 @@ class CouponRepository
             val userId = authManager.currentUserIdFlow.filterNotNull().first()
             couponDao.insert(coupon.copy(userId = userId).toEntity())
             return coupon.id
-        }
-
-        suspend fun updateAiRecognitionInfo(
-            couponId: String,
-            couponInfo: CouponInfo?,
-            success: Boolean,
-        ) {
-            val now = System.currentTimeMillis()
-            val status =
-                if (success) {
-                    CouponStatus.SUCCESS.name
-                } else {
-                    CouponStatus.AI_FAILED.name
-                }
-            val finalExpiryDate =
-                when {
-                    !couponInfo?.expiryDate.isNullOrEmpty() -> {
-                        couponInfo.expiryDate.takeIf {
-                            runCatching {
-                                LocalDate.parse(
-                                    it,
-                                    DateTimeFormatter.ISO_LOCAL_DATE,
-                                )
-                            }.isSuccess
-                        }
-                    }
-
-                    couponInfo?.dday != null -> {
-                        LocalDate
-                            .now()
-                            .plusDays(-couponInfo.dday.toLong())
-                            .format(DateTimeFormatter.ISO_LOCAL_DATE)
-                    }
-
-                    else -> {
-                        null
-                    }
-                }
-
-            couponDao.updateAiRecognitionInfo(
-                couponId = couponId,
-                productName = couponInfo?.productName,
-                brand = couponInfo?.brand,
-                couponPin = couponInfo?.couponPin,
-                expiryDate = finalExpiryDate,
-                isMonetary = couponInfo?.isMonetary,
-                amount = couponInfo?.amount,
-                category = couponInfo?.category,
-                updatedAt = now,
-                status = status,
-            )
         }
 
         suspend fun updateR2Info(
@@ -238,23 +185,21 @@ class CouponRepository
             couponId: String,
             imageUrl: String,
             barcode: String?,
-        ): Result<AiCouponResponse> =
+            createAt: String,
+        ): Result<CouponDto> =
             try {
                 val response: AiCouponResponse =
                     authClient
                         .post("${BuildConfig.BASE_URL}/analyze") {
                             contentType(ContentType.Application.Json)
-                            setBody(
-                                AiAnalyzeRequest(
-                                    couponId = couponId,
-                                    imageUrl = imageUrl,
-                                    barcode = barcode,
-                                ),
-                                // @AuthClient이므로 Bearer 토큰 자동 삽입됨
-                            )
+                            setBody(AiAnalyzeRequest(couponId, imageUrl, barcode, createAt))
                         }.body()
 
-                Result.success(response)
+                if (response.success) {
+                    Result.success(response.data)
+                } else {
+                    Result.failure(Exception("분석 실패 (서버 로직 에러)"))
+                }
             } catch (e: ClientRequestException) {
                 Result.failure(Exception("분석 실패: ${e.response.status}"))
             } catch (e: TimeoutCancellationException) {
@@ -262,6 +207,30 @@ class CouponRepository
             } catch (e: Exception) {
                 Result.failure(Exception("분석 중 알 수 없는 오류 발생: ${e.localizedMessage}"))
             }
+
+        suspend fun syncCouponFromServer(dto: CouponDto) {
+            val localCoupon = couponDao.getCouponById(dto.id)
+
+            // 1. 충돌 방지: 사용자가 수동 수정을 시작했다면(isDirty) 서버 데이터로 덮어쓰지 않음
+            if (localCoupon?.isDirty == true) return
+
+            // 2. DTO -> Entity 변환 (로컬 경로 보존)
+            // localCoupon이 있다면 기존 localImagePath를 가져와서 합쳐줍니다.
+            val entity =
+                dto.toEntity(
+                    existingLocalPath = localCoupon?.localImagePath,
+                )
+
+            // 3. 로컬 DB 갱신
+            couponDao.insert(entity)
+        }
+
+        suspend fun updateStatus(
+            id: String,
+            couponStatus: String,
+        ) {
+            couponDao.updateStatus(id, couponStatus)
+        }
 
         suspend fun markAsUsed(
             id: String,

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -10,6 +10,7 @@ import com.conkeep.data.local.dao.CouponDao
 import com.conkeep.data.local.entity.CouponStatus
 import com.conkeep.data.mapper.toDomain
 import com.conkeep.data.mapper.toEntity
+import com.conkeep.data.remote.dto.AiAnalyzeRequest
 import com.conkeep.data.remote.dto.AiCouponResponse
 import com.conkeep.data.remote.dto.CouponInfo
 import com.conkeep.data.remote.dto.PresignedUrlResponse
@@ -54,234 +55,244 @@ import javax.inject.Singleton
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class CouponRepository
-@Inject
-constructor(
-    private val supabase: SupabaseClient,
-    private val couponDao: CouponDao,
-    private val authManager: SupabaseAuthManager,
-    @param:R2UploadClient private val r2Client: HttpClient,
-    @param:AuthClient private val authClient: HttpClient,
-) {
-    fun searchCoupons(
-        query: String,
-        today: String,
-        filterType: Int,
-        sortType: Int,
-    ): Flow<PagingData<Coupon>> =
-        authManager.currentUserIdFlow
-            .filterNotNull()
-            .flatMapLatest { userId ->
-                Pager(
-                    config =
-                        PagingConfig(
-                            pageSize = 20,
-                            enablePlaceholders = false,
-                            initialLoadSize = 40,
-                        ),
-                    initialKey = 0,
-                    pagingSourceFactory = {
-                        couponDao.searchCouponsPaging(
-                            userId = userId,
-                            searchQuery = query,
-                            today = today,
-                            filterType = filterType,
-                            sortType = sortType,
-                        )
-                    },
-                ).flow
-            }.map { pagingData ->
-                pagingData.map { it.toDomain() }
-            }
-
-    fun getCouponCount(
-        query: String,
-        today: String,
-        filterType: Int,
-    ): Flow<Int> =
-        authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
-            couponDao.getCouponsCount(userId, query, today, filterType)
-        }
-
-    fun getCouponSummary(today: String): Flow<CouponCountSummary> =
-        authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
-            couponDao.getCouponSummaryFlow(
-                userId = userId,
-                today = today,
-            )
-        }
-
-    fun getCoupon(id: String): Flow<Coupon?> =
-        couponDao
-            .getCouponFlow(id)
-            .map { entity -> entity?.toDomain() }
-
-    suspend fun addCoupon(coupon: Coupon): String {
-        // currentUserIdFlow의 가장 최신 유효 값을 가져옴
-        val userId = authManager.currentUserIdFlow.filterNotNull().first()
-        couponDao.insert(coupon.copy(userId = userId).toEntity())
-        return coupon.id
-    }
-
-    suspend fun updateAiRecognitionInfo(
-        couponId: String,
-        couponInfo: CouponInfo?,
-        success: Boolean,
+    @Inject
+    constructor(
+        private val supabase: SupabaseClient,
+        private val couponDao: CouponDao,
+        private val authManager: SupabaseAuthManager,
+        @param:R2UploadClient private val r2Client: HttpClient,
+        @param:AuthClient private val authClient: HttpClient,
     ) {
-        val now = System.currentTimeMillis()
-        val status =
-            if (success) {
-                CouponStatus.SUCCESS.name
-            } else {
-                CouponStatus.AI_FAILED.name
-            }
-        val finalExpiryDate =
-            when {
-                !couponInfo?.expiryDate.isNullOrEmpty() -> {
-                    couponInfo.expiryDate.takeIf {
-                        runCatching {
-                            LocalDate.parse(
-                                it,
-                                DateTimeFormatter.ISO_LOCAL_DATE,
+        fun searchCoupons(
+            query: String,
+            today: String,
+            filterType: Int,
+            sortType: Int,
+        ): Flow<PagingData<Coupon>> =
+            authManager.currentUserIdFlow
+                .filterNotNull()
+                .flatMapLatest { userId ->
+                    Pager(
+                        config =
+                            PagingConfig(
+                                pageSize = 20,
+                                enablePlaceholders = false,
+                                initialLoadSize = 40,
+                            ),
+                        initialKey = 0,
+                        pagingSourceFactory = {
+                            couponDao.searchCouponsPaging(
+                                userId = userId,
+                                searchQuery = query,
+                                today = today,
+                                filterType = filterType,
+                                sortType = sortType,
                             )
-                        }.isSuccess
-                    }
+                        },
+                    ).flow
+                }.map { pagingData ->
+                    pagingData.map { it.toDomain() }
                 }
 
-                couponInfo?.dday != null -> {
-                    LocalDate
-                        .now()
-                        .plusDays(-couponInfo.dday.toLong())
-                        .format(DateTimeFormatter.ISO_LOCAL_DATE)
-                }
-
-                else -> {
-                    null
-                }
+        fun getCouponCount(
+            query: String,
+            today: String,
+            filterType: Int,
+        ): Flow<Int> =
+            authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
+                couponDao.getCouponsCount(userId, query, today, filterType)
             }
 
-        couponDao.updateAiRecognitionInfo(
-            couponId = couponId,
-            productName = couponInfo?.productName,
-            brand = couponInfo?.brand,
-            couponPin = couponInfo?.couponPin,
-            expiryDate = finalExpiryDate,
-            isMonetary = couponInfo?.isMonetary,
-            amount = couponInfo?.amount,
-            category = couponInfo?.category,
-            updatedAt = now,
-            status = status,
-        )
-    }
+        fun getCouponSummary(today: String): Flow<CouponCountSummary> =
+            authManager.currentUserIdFlow.filterNotNull().flatMapLatest { userId ->
+                couponDao.getCouponSummaryFlow(
+                    userId = userId,
+                    today = today,
+                )
+            }
 
-    suspend fun updateR2Info(
-        couponId: String,
-        r2Url: String,
-        r2Key: String,
-    ) {
-        couponDao.updateR2Info(couponId, r2Url, r2Key)
-    }
+        fun getCoupon(id: String): Flow<Coupon?> =
+            couponDao
+                .getCouponFlow(id)
+                .map { entity -> entity?.toDomain() }
 
-    suspend fun getPresignedUrl(
-        file: File,
-        contentType: String,
-    ): Result<PresignedUrlResponse> =
-        withContext(Dispatchers.IO) {
-            try {
-                val response =
-                    authClient.get("${BuildConfig.BASE_URL}/upload-url") {
-                        url {
-                            parameters.append("ext", file.extension.lowercase())
-                            parameters.append("contentType", contentType)
-                            parameters.append("fileSize", file.length().toString())
+        suspend fun addCoupon(coupon: Coupon): String {
+            // currentUserIdFlow의 가장 최신 유효 값을 가져옴
+            val userId = authManager.currentUserIdFlow.filterNotNull().first()
+            couponDao.insert(coupon.copy(userId = userId).toEntity())
+            return coupon.id
+        }
+
+        suspend fun updateAiRecognitionInfo(
+            couponId: String,
+            couponInfo: CouponInfo?,
+            success: Boolean,
+        ) {
+            val now = System.currentTimeMillis()
+            val status =
+                if (success) {
+                    CouponStatus.SUCCESS.name
+                } else {
+                    CouponStatus.AI_FAILED.name
+                }
+            val finalExpiryDate =
+                when {
+                    !couponInfo?.expiryDate.isNullOrEmpty() -> {
+                        couponInfo.expiryDate.takeIf {
+                            runCatching {
+                                LocalDate.parse(
+                                    it,
+                                    DateTimeFormatter.ISO_LOCAL_DATE,
+                                )
+                            }.isSuccess
                         }
                     }
 
-                if (response.status == HttpStatusCode.OK) {
-                    Result.success(response.body<PresignedUrlResponse>())
-                } else {
-                    Result.failure(Exception("PresignedUrl 생성 실패: ${response.status}"))
-                }
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-    suspend fun uploadCouponImageR2(
-        imageFile: File,
-        uploadUrl: String,
-        contentType: String,
-    ): Result<Unit> =
-        withContext(Dispatchers.IO) {
-            if (!imageFile.exists()) {
-                return@withContext Result.failure(Exception("파일이 존재하지 않습니다: ${imageFile.absolutePath}"))
-            }
-            try {
-                val response: HttpResponse =
-                    r2Client.put(uploadUrl) {
-                        setBody(imageFile.readChannel())
-                        contentType(ContentType.parse(contentType))
-                        header(HttpHeaders.ContentLength, imageFile.length().toString())
+                    couponInfo?.dday != null -> {
+                        LocalDate
+                            .now()
+                            .plusDays(-couponInfo.dday.toLong())
+                            .format(DateTimeFormatter.ISO_LOCAL_DATE)
                     }
 
-                if (response.status.isSuccess()) {
-                    Result.success(Unit)
-                } else {
-                    Result.failure(Exception("R2 업로드 실패: ${response.status}"))
+                    else -> {
+                        null
+                    }
                 }
-            } catch (e: Exception) {
-                Result.failure(e)
+
+            couponDao.updateAiRecognitionInfo(
+                couponId = couponId,
+                productName = couponInfo?.productName,
+                brand = couponInfo?.brand,
+                couponPin = couponInfo?.couponPin,
+                expiryDate = finalExpiryDate,
+                isMonetary = couponInfo?.isMonetary,
+                amount = couponInfo?.amount,
+                category = couponInfo?.category,
+                updatedAt = now,
+                status = status,
+            )
+        }
+
+        suspend fun updateR2Info(
+            couponId: String,
+            r2Url: String,
+            r2Key: String,
+        ) {
+            couponDao.updateR2Info(couponId, r2Url, r2Key)
+        }
+
+        suspend fun getPresignedUrl(
+            file: File,
+            contentType: String,
+        ): Result<PresignedUrlResponse> =
+            withContext(Dispatchers.IO) {
+                try {
+                    val response =
+                        authClient.get("${BuildConfig.BASE_URL}/upload-url") {
+                            url {
+                                parameters.append("ext", file.extension.lowercase())
+                                parameters.append("contentType", contentType)
+                                parameters.append("fileSize", file.length().toString())
+                            }
+                        }
+
+                    if (response.status == HttpStatusCode.OK) {
+                        Result.success(response.body<PresignedUrlResponse>())
+                    } else {
+                        Result.failure(Exception("PresignedUrl 생성 실패: ${response.status}"))
+                    }
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
             }
-        }
 
-    suspend fun aiCouponRecognizing(imageUrl: String): Result<AiCouponResponse> =
-        try {
-            val response: AiCouponResponse =
-                authClient
-                    .post("${BuildConfig.BASE_URL}/analyze") {
-                        contentType(ContentType.Application.Json)
-                        setBody(mapOf("imageUrl" to imageUrl))
-                        // @AuthClient이므로 Bearer 토큰 자동 삽입됨
-                    }.body()
+        suspend fun uploadCouponImageR2(
+            imageFile: File,
+            uploadUrl: String,
+            contentType: String,
+        ): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                if (!imageFile.exists()) {
+                    return@withContext Result.failure(Exception("파일이 존재하지 않습니다: ${imageFile.absolutePath}"))
+                }
+                try {
+                    val response: HttpResponse =
+                        r2Client.put(uploadUrl) {
+                            setBody(imageFile.readChannel())
+                            contentType(ContentType.parse(contentType))
+                            header(HttpHeaders.ContentLength, imageFile.length().toString())
+                        }
 
-            Result.success(response)
-        } catch (e: ClientRequestException) {
-            Result.failure(Exception("분석 실패: ${e.response.status}"))
-        } catch (_: TimeoutCancellationException) {
-            Result.failure(Exception("분석 시간 초과"))
-        } catch (e: Exception) {
-            Result.failure(Exception("분석 오류: ${e.message}"))
-        }
+                    if (response.status.isSuccess()) {
+                        Result.success(Unit)
+                    } else {
+                        Result.failure(Exception("R2 업로드 실패: ${response.status}"))
+                    }
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
 
-    suspend fun markAsUsed(
-        id: String,
-        timestamp: Long,
-    ) {
-        couponDao.markAsUsed(id, timestamp)
-    }
-
-    // 백그라운드에서 Supabase → Room 동기화
-    suspend fun syncFromSupabase(): Result<Unit> =
-        withContext(Dispatchers.IO) {
+        suspend fun aiCouponRecognizing(
+            couponId: String,
+            imageUrl: String,
+            barcode: String?,
+        ): Result<AiCouponResponse> =
             try {
-                val userId =
-                    authManager.currentUserIdFlow.first()
-                        ?: return@withContext Result.failure(Exception("Not logged in"))
+                val response: AiCouponResponse =
+                    authClient
+                        .post("${BuildConfig.BASE_URL}/analyze") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                AiAnalyzeRequest(
+                                    couponId = couponId,
+                                    imageUrl = imageUrl,
+                                    barcode = barcode,
+                                ),
+                                // @AuthClient이므로 Bearer 토큰 자동 삽입됨
+                            )
+                        }.body()
 
-                val remoteCoupons =
-                    supabase
-                        .from("coupons")
-                        .select {
-                            filter { eq("user_id", userId) }
-                        }.decodeList<SupabaseCoupon>()
-
-                couponDao.insertAll(remoteCoupons.map { it.toEntity() })
-                Result.success(Unit)
+                Result.success(response)
+            } catch (e: ClientRequestException) {
+                Result.failure(Exception("분석 실패: ${e.response.status}"))
+            } catch (e: TimeoutCancellationException) {
+                Result.failure(Exception("분석 시간 초과 (네트워크 상태를 확인하세요)"))
             } catch (e: Exception) {
-                Result.failure(e)
+                Result.failure(Exception("분석 중 알 수 없는 오류 발생: ${e.localizedMessage}"))
             }
+
+        suspend fun markAsUsed(
+            id: String,
+            timestamp: Long,
+        ) {
+            couponDao.markAsUsed(id, timestamp)
         }
 
-    // TODO : 로컬 변경사항 → Supabase 업로드
+        // 백그라운드에서 Supabase → Room 동기화
+        suspend fun syncFromSupabase(): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                try {
+                    val userId =
+                        authManager.currentUserIdFlow.first()
+                            ?: return@withContext Result.failure(Exception("Not logged in"))
+
+                    val remoteCoupons =
+                        supabase
+                            .from("coupons")
+                            .select {
+                                filter { eq("user_id", userId) }
+                            }.decodeList<SupabaseCoupon>()
+
+                    couponDao.insertAll(remoteCoupons.map { it.toEntity() })
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
+
+        // TODO : 로컬 변경사항 → Supabase 업로드
 //        suspend fun syncToSupabase(coupon: Coupon): Result<Unit> =
 //            withContext(Dispatchers.IO) {
 //                try {
@@ -298,4 +309,4 @@ constructor(
 //                    Result.failure(e)
 //                }
 //            }
-}
+    }

--- a/app/src/main/java/com/conkeep/domain/model/Coupon.kt
+++ b/app/src/main/java/com/conkeep/domain/model/Coupon.kt
@@ -1,7 +1,7 @@
 package com.conkeep.domain.model
 
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
+import kotlin.time.Instant
 
 data class Coupon(
     val id: String,
@@ -24,10 +24,10 @@ data class Coupon(
     val userMemo: String?,
     // 사용 정보
     val isUsed: Boolean,
-    val usedAt: LocalDateTime?,
+    val usedAt: Instant?,
     // 메타데이터
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime,
+    val createdAt: Instant,
+    val updatedAt: Instant,
     val isSynced: Boolean,
     // 쿠폰 저장 상태
     val status: String?,

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListViewModel.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListViewModel.kt
@@ -8,9 +8,9 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.conkeep.data.local.entity.CouponStatus
-import com.conkeep.data.mapper.toCouponCategory
 import com.conkeep.data.processor.CouponPreProcessResult
 import com.conkeep.data.processor.CouponProcessor
+import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.data.repository.coupon.CouponRepository
 import com.conkeep.domain.model.Coupon
 import com.conkeep.domain.model.CouponCategory
@@ -39,12 +39,11 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import java.io.File
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -90,7 +89,7 @@ class CouponListViewModel
                         query = config.query,
                         today = todayIso8601,
                         filterType = config.filter.value,
-                        sortType = config.sort.sortType,
+                        sortType = config.sort,
                     ).map { pagingData ->
                         pagingData.map { it.toUiModel(today = timeProvider.getToday()) }
                     }
@@ -184,13 +183,15 @@ class CouponListViewModel
 
         fun addCouponFromUri(uri: Uri) {
             viewModelScope.launch {
+                var couponId: String? = null
                 try {
                     // 1. 전처리
                     val preProcessResult = couponProcessor.preProcessImage(uri)
                     val path = preProcessResult.localPath ?: throw IllegalStateException("로컬 경로 없음")
 
                     // 2. 순차적 처리 (Fail-Fast)
-                    val couponId = addPreCouponToDb(preProcessResult)
+                    val (id, createdInstant) = addPreCouponToDb(preProcessResult)
+                    couponId = id
                     _couponAddedEvent.emit(couponId)
                     val urlResponse =
                         couponRepository
@@ -219,45 +220,43 @@ class CouponListViewModel
                             couponId,
                             urlResponse.imageUrl,
                             preProcessResult.barcode,
+                            createdInstant.toString(), // "2026-02-13T14:41:00Z" (끝에 Z가 붙음)
                         )
                     aiResponse.fold(
-                        onSuccess = { response ->
-                            // 성공: RECOGNIZED + 쿠폰 정보
-                            val finalCouponInfo =
-                                response.data.copy(
+                        onSuccess = { dto: CouponDto ->
+                            val finalDto =
+                                dto.copy(
                                     couponPin =
                                         preProcessResult.barcode.takeUnless { it.isNullOrEmpty() }
-                                            ?: response.data.couponPin?.filter { !it.isWhitespace() },
-                                    category =
-                                        response.data.category
-                                            .toCouponCategory()
-                                            .name,
+                                            ?: dto.couponPin,
+                                    status = CouponStatus.SUCCESS.name,
                                 )
-                            couponRepository.updateAiRecognitionInfo(
-                                couponId,
-                                finalCouponInfo,
-                                success = true,
-                            )
+
+                            couponRepository.syncCouponFromServer(finalDto)
+                            Log.d("CouponViewModel", "AI 분석 및 동기화 성공: ${dto.createdAt}, ${dto.id}")
                         },
                         onFailure = {
                             // 실패: FAILED 상태
-                            couponRepository.updateAiRecognitionInfo(
+                            couponRepository.updateStatus(
                                 couponId,
-                                null,
-                                success = false,
+                                CouponStatus.AI_FAILED.name,
                             )
                         },
                     )
                 } catch (e: Exception) {
+                    couponId?.let {
+                        couponRepository.updateStatus(it, CouponStatus.AI_FAILED.name)
+                    }
+
                     Log.e("CouponViewModel", "쿠폰 등록 실패: ${e.message}")
                 }
             }
         }
 
-        private suspend fun addPreCouponToDb(couponPreProcessResult: CouponPreProcessResult): String {
-            val now = Clock.System.now()
-            val localDateTime = now.toLocalDateTime(TimeZone.currentSystemDefault())
+        private suspend fun addPreCouponToDb(couponPreProcessResult: CouponPreProcessResult): Pair<String, Instant> {
+            val nowInstant = Clock.System.now()
             val localId = UUID.randomUUID().toString()
+            Log.d("CouponViewModel", "$nowInstant, 로컬 ID: $localId")
 
             val preCoupon =
                 Coupon(
@@ -277,15 +276,15 @@ class CouponListViewModel
                     userMemo = null,
                     isUsed = false,
                     usedAt = null,
-                    createdAt = localDateTime,
-                    updatedAt = localDateTime,
+                    createdAt = nowInstant,
+                    updatedAt = nowInstant,
                     isSynced = false,
                     status = CouponStatus.ANALYZING.name,
                 )
 
             // Repository 호출 → ID 반환 받음
             couponRepository.addCoupon(preCoupon)
-            return localId // 로컬 ID 반환
+            return localId to nowInstant // 로컬 ID 반환
         }
 
         companion object {

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListViewModel.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListViewModel.kt
@@ -49,242 +49,246 @@ import kotlin.time.Clock
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class CouponListViewModel
-@Inject
-constructor(
-    private val couponRepository: CouponRepository,
-    private val couponProcessor: CouponProcessor,
-    private val timeProvider: TimeProvider,
-) : ViewModel() {
-    private val _queryConfig = MutableStateFlow(CouponQueryConfig())
-    val queryConfig = _queryConfig.asStateFlow()
+    @Inject
+    constructor(
+        private val couponRepository: CouponRepository,
+        private val couponProcessor: CouponProcessor,
+        private val timeProvider: TimeProvider,
+    ) : ViewModel() {
+        private val _queryConfig = MutableStateFlow(CouponQueryConfig())
+        val queryConfig = _queryConfig.asStateFlow()
 
-    private val _resetTrigger = MutableStateFlow(0)
-    val resetTrigger = _resetTrigger.asStateFlow()
+        private val _resetTrigger = MutableStateFlow(0)
+        val resetTrigger = _resetTrigger.asStateFlow()
 
-    private val _searchQueryInput = MutableStateFlow("")
-    val searchQueryInput = _searchQueryInput.asStateFlow()
+        private val _searchQueryInput = MutableStateFlow("")
+        val searchQueryInput = _searchQueryInput.asStateFlow()
 
-    private val _couponAddedEvent = MutableSharedFlow<String>()
-    val couponAddedEvent = _couponAddedEvent.asSharedFlow()
+        private val _couponAddedEvent = MutableSharedFlow<String>()
+        val couponAddedEvent = _couponAddedEvent.asSharedFlow()
 
-    private val todayIso8601: String = timeProvider.getToday().toString()
+        private val todayIso8601: String = timeProvider.getToday().toString()
 
-    init {
-        viewModelScope.launch {
-            searchQueryInput
-                .debounce { query ->
-                    if (query.isBlank()) 0L else DEBOUNCE_TIMEOUT
-                }.distinctUntilChanged()
-                .collect { debouncedQuery ->
-                    _queryConfig.value = _queryConfig.value.copy(query = debouncedQuery)
-                }
-        }
-    }
-
-    val coupons: Flow<PagingData<CouponUiModel>> =
-        combine(queryConfig, resetTrigger) { config, _ ->
-            config
-        }.flatMapLatest { config ->
-            couponRepository
-                .searchCoupons(
-                    query = config.query,
-                    today = todayIso8601,
-                    filterType = config.filter.value,
-                    sortType = config.sort.sortType,
-                ).map { pagingData ->
-                    pagingData.map { it.toUiModel(today = timeProvider.getToday()) }
-                }
-        }.cachedIn(viewModelScope)
-
-    val couponCountHeaderState: StateFlow<CouponCountHeaderState> =
-        _queryConfig
-            .flatMapLatest { config ->
-                couponRepository
-                    .getCouponCount(config.query, todayIso8601, config.filter.value)
-                    .map { count ->
-                        CouponCountHeaderState(
-                            totalCount = count,
-                            isSearchActive = config.query.isNotBlank(),
-                        )
+        init {
+            viewModelScope.launch {
+                searchQueryInput
+                    .debounce { query ->
+                        if (query.isBlank()) 0L else DEBOUNCE_TIMEOUT
+                    }.distinctUntilChanged()
+                    .collect { debouncedQuery ->
+                        _queryConfig.value = _queryConfig.value.copy(query = debouncedQuery)
                     }
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CouponCountHeaderState())
-    val couponCountSummary: StateFlow<CouponCountSummary> =
-        couponRepository
-            .getCouponSummary(todayIso8601)
-            .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(5000),
-                CouponCountSummary(),
-            )
+        }
 
-    /**
-     * 새로 등록된 쿠폰을 보여주기 위한 준비
-     */
-    fun readyToShowNewCoupon() {
-        _searchQueryInput.value = "" // 입력 Flow 즉시 비우기 (디바운스 덮어쓰기 방지)
-        _queryConfig.value =
-            CouponQueryConfig(
-                query = "",
-                filter = CouponFilterType.ALL,
-                sort = CouponSortType.RECENT_ADD,
-            )
-        _resetTrigger.value += 1
-    }
+        val coupons: Flow<PagingData<CouponUiModel>> =
+            combine(queryConfig, resetTrigger) { config, _ ->
+                config
+            }.flatMapLatest { config ->
+                couponRepository
+                    .searchCoupons(
+                        query = config.query,
+                        today = todayIso8601,
+                        filterType = config.filter.value,
+                        sortType = config.sort.sortType,
+                    ).map { pagingData ->
+                        pagingData.map { it.toUiModel(today = timeProvider.getToday()) }
+                    }
+            }.cachedIn(viewModelScope)
 
-    /**
-     * 검색 키워드만 리셋(필터는 유지)
-     */
-    fun clearSearchKeyword() {
-        _searchQueryInput.value = "" // 입력 Flow 즉시 비우기 (디바운스 덮어쓰기 방지)
-        _queryConfig.value =
-            queryConfig.value.copy(
-                query = "",
-            )
-    }
-
-    fun searchCoupons(query: String) {
-        _searchQueryInput.value = query
-    }
-
-    fun toggleCouponSortType() {
-        _queryConfig.value =
-            queryConfig.value.copy(
-                sort =
-                    when (queryConfig.value.filter) {
-                        CouponFilterType.USED -> {
-                            when (queryConfig.value.sort) {
-                                CouponSortType.RECENT_USED -> CouponSortType.EXPIRY
-                                CouponSortType.EXPIRY -> CouponSortType.RECENT_USED
-                                else -> CouponSortType.EXPIRY
-                            }
-                        }
-
-                        else -> {
-                            when (queryConfig.value.sort) {
-                                CouponSortType.RECENT_ADD -> CouponSortType.EXPIRY
-                                CouponSortType.EXPIRY -> CouponSortType.RECENT_ADD
-                                else -> CouponSortType.EXPIRY
-                            }
-                        }
-                    },
-            )
-    }
-
-    fun changeCouponFilterType(filterType: CouponFilterType) {
-        _queryConfig.value =
-            queryConfig.value.copy(
-                filter = filterType,
-                sort =
-                    when (filterType) {
-                        CouponFilterType.USED -> CouponSortType.RECENT_USED
-                        else -> CouponSortType.EXPIRY
-                    },
-            )
-    }
-
-    fun addCouponFromUri(uri: Uri) {
-        viewModelScope.launch {
-            try {
-                // 1. 전처리
-                val preProcessResult = couponProcessor.preProcessImage(uri)
-                val path = preProcessResult.localPath ?: throw IllegalStateException("로컬 경로 없음")
-
-                // 2. 순차적 처리 (Fail-Fast)
-                val couponId = addPreCouponToDb(preProcessResult)
-                _couponAddedEvent.emit(couponId)
-                val urlResponse =
+        val couponCountHeaderState: StateFlow<CouponCountHeaderState> =
+            _queryConfig
+                .flatMapLatest { config ->
                     couponRepository
-                        .getPresignedUrl(
+                        .getCouponCount(config.query, todayIso8601, config.filter.value)
+                        .map { count ->
+                            CouponCountHeaderState(
+                                totalCount = count,
+                                isSearchActive = config.query.isNotBlank(),
+                            )
+                        }
+                }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CouponCountHeaderState())
+        val couponCountSummary: StateFlow<CouponCountSummary> =
+            couponRepository
+                .getCouponSummary(todayIso8601)
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5000),
+                    CouponCountSummary(),
+                )
+
+        /**
+         * 새로 등록된 쿠폰을 보여주기 위한 준비
+         */
+        fun readyToShowNewCoupon() {
+            _searchQueryInput.value = "" // 입력 Flow 즉시 비우기 (디바운스 덮어쓰기 방지)
+            _queryConfig.value =
+                CouponQueryConfig(
+                    query = "",
+                    filter = CouponFilterType.ALL,
+                    sort = CouponSortType.RECENT_ADD,
+                )
+            _resetTrigger.value += 1
+        }
+
+        /**
+         * 검색 키워드만 리셋(필터는 유지)
+         */
+        fun clearSearchKeyword() {
+            _searchQueryInput.value = "" // 입력 Flow 즉시 비우기 (디바운스 덮어쓰기 방지)
+            _queryConfig.value =
+                queryConfig.value.copy(
+                    query = "",
+                )
+        }
+
+        fun searchCoupons(query: String) {
+            _searchQueryInput.value = query
+        }
+
+        fun toggleCouponSortType() {
+            _queryConfig.value =
+                queryConfig.value.copy(
+                    sort =
+                        when (queryConfig.value.filter) {
+                            CouponFilterType.USED -> {
+                                when (queryConfig.value.sort) {
+                                    CouponSortType.RECENT_USED -> CouponSortType.EXPIRY
+                                    CouponSortType.EXPIRY -> CouponSortType.RECENT_USED
+                                    else -> CouponSortType.EXPIRY
+                                }
+                            }
+
+                            else -> {
+                                when (queryConfig.value.sort) {
+                                    CouponSortType.RECENT_ADD -> CouponSortType.EXPIRY
+                                    CouponSortType.EXPIRY -> CouponSortType.RECENT_ADD
+                                    else -> CouponSortType.EXPIRY
+                                }
+                            }
+                        },
+                )
+        }
+
+        fun changeCouponFilterType(filterType: CouponFilterType) {
+            _queryConfig.value =
+                queryConfig.value.copy(
+                    filter = filterType,
+                    sort =
+                        when (filterType) {
+                            CouponFilterType.USED -> CouponSortType.RECENT_USED
+                            else -> CouponSortType.EXPIRY
+                        },
+                )
+        }
+
+        fun addCouponFromUri(uri: Uri) {
+            viewModelScope.launch {
+                try {
+                    // 1. 전처리
+                    val preProcessResult = couponProcessor.preProcessImage(uri)
+                    val path = preProcessResult.localPath ?: throw IllegalStateException("로컬 경로 없음")
+
+                    // 2. 순차적 처리 (Fail-Fast)
+                    val couponId = addPreCouponToDb(preProcessResult)
+                    _couponAddedEvent.emit(couponId)
+                    val urlResponse =
+                        couponRepository
+                            .getPresignedUrl(
+                                File(path),
+                                preProcessResult.mimeType ?: "image/jpeg",
+                            ).getOrThrow()
+
+                    couponRepository
+                        .uploadCouponImageR2(
                             File(path),
+                            urlResponse.uploadPresignedUrl,
                             preProcessResult.mimeType ?: "image/jpeg",
                         ).getOrThrow()
 
-                couponRepository
-                    .uploadCouponImageR2(
-                        File(path),
-                        urlResponse.uploadPresignedUrl,
-                        preProcessResult.mimeType ?: "image/jpeg",
-                    ).getOrThrow()
+                    // 3. 성공 후 업데이트
+                    couponRepository.updateR2Info(
+                        couponId,
+                        urlResponse.imageUrl,
+                        urlResponse.r2ObjectKey,
+                    )
 
-                // 3. 성공 후 업데이트
-                couponRepository.updateR2Info(
-                    couponId,
-                    urlResponse.imageUrl,
-                    urlResponse.r2ObjectKey,
-                )
-
-                // AI 성공 시 추가 업데이트
-                val aiResponse = couponRepository.aiCouponRecognizing(urlResponse.imageUrl)
-                aiResponse.fold(
-                    onSuccess = { response ->
-                        // 성공: RECOGNIZED + 쿠폰 정보
-                        val finalCouponInfo =
-                            response.data.copy(
-                                couponPin =
-                                    preProcessResult.barcode.takeUnless { it.isNullOrEmpty() }
-                                        ?: response.data.couponPin?.filter { !it.isWhitespace() },
-                                category =
-                                    response.data.category
-                                        .toCouponCategory()
-                                        .name,
+                    // AI 성공 시 추가 업데이트
+                    val aiResponse =
+                        couponRepository.aiCouponRecognizing(
+                            couponId,
+                            urlResponse.imageUrl,
+                            preProcessResult.barcode,
+                        )
+                    aiResponse.fold(
+                        onSuccess = { response ->
+                            // 성공: RECOGNIZED + 쿠폰 정보
+                            val finalCouponInfo =
+                                response.data.copy(
+                                    couponPin =
+                                        preProcessResult.barcode.takeUnless { it.isNullOrEmpty() }
+                                            ?: response.data.couponPin?.filter { !it.isWhitespace() },
+                                    category =
+                                        response.data.category
+                                            .toCouponCategory()
+                                            .name,
+                                )
+                            couponRepository.updateAiRecognitionInfo(
+                                couponId,
+                                finalCouponInfo,
+                                success = true,
                             )
-                        couponRepository.updateAiRecognitionInfo(
-                            couponId,
-                            finalCouponInfo,
-                            success = true,
-                        )
-                    },
-                    onFailure = {
-                        // 실패: FAILED 상태
-                        couponRepository.updateAiRecognitionInfo(
-                            couponId,
-                            null,
-                            success = false,
-                        )
-                    },
-                )
-            } catch (e: Exception) {
-                Log.e("CouponViewModel", "쿠폰 등록 실패: ${e.message}")
+                        },
+                        onFailure = {
+                            // 실패: FAILED 상태
+                            couponRepository.updateAiRecognitionInfo(
+                                couponId,
+                                null,
+                                success = false,
+                            )
+                        },
+                    )
+                } catch (e: Exception) {
+                    Log.e("CouponViewModel", "쿠폰 등록 실패: ${e.message}")
+                }
             }
         }
+
+        private suspend fun addPreCouponToDb(couponPreProcessResult: CouponPreProcessResult): String {
+            val now = Clock.System.now()
+            val localDateTime = now.toLocalDateTime(TimeZone.currentSystemDefault())
+            val localId = UUID.randomUUID().toString()
+
+            val preCoupon =
+                Coupon(
+                    id = localId,
+                    userId = "", // supabase user_id
+                    imageUrl = null,
+                    imageKey = null,
+                    thumbnailUrl = null,
+                    localImagePath = couponPreProcessResult.localPath,
+                    productName = null,
+                    brand = null,
+                    couponPin = couponPreProcessResult.barcode,
+                    expiryDate = null,
+                    isMonetary = false,
+                    amount = null,
+                    category = CouponCategory.ETC,
+                    userMemo = null,
+                    isUsed = false,
+                    usedAt = null,
+                    createdAt = localDateTime,
+                    updatedAt = localDateTime,
+                    isSynced = false,
+                    status = CouponStatus.ANALYZING.name,
+                )
+
+            // Repository 호출 → ID 반환 받음
+            couponRepository.addCoupon(preCoupon)
+            return localId // 로컬 ID 반환
+        }
+
+        companion object {
+            private const val DEBOUNCE_TIMEOUT = 500L
+        }
     }
-
-    private suspend fun addPreCouponToDb(couponPreProcessResult: CouponPreProcessResult): String {
-        val now = Clock.System.now()
-        val localDateTime = now.toLocalDateTime(TimeZone.currentSystemDefault())
-        val localId = UUID.randomUUID().toString()
-
-        val preCoupon =
-            Coupon(
-                id = localId,
-                userId = "", // supabase user_id
-                imageUrl = null,
-                imageKey = null,
-                thumbnailUrl = null,
-                localImagePath = couponPreProcessResult.localPath,
-                productName = null,
-                brand = null,
-                couponPin = couponPreProcessResult.barcode,
-                expiryDate = null,
-                isMonetary = false,
-                amount = null,
-                category = CouponCategory.ETC,
-                userMemo = null,
-                isUsed = false,
-                usedAt = null,
-                createdAt = localDateTime,
-                updatedAt = localDateTime,
-                isSynced = false,
-                status = CouponStatus.ANALYZING.name,
-            )
-
-        // Repository 호출 → ID 반환 받음
-        couponRepository.addCoupon(preCoupon)
-        return localId // 로컬 ID 반환
-    }
-
-    companion object {
-        private const val DEBOUNCE_TIMEOUT = 500L
-    }
-}


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #52 

## 📋 작업 내용
ai분석 요청시 쿠폰아이디, 바코드, 생성시각를 같이 보내고 
백엔드에서 슈파베이스에 ai분석 결과를 기록을 하며 기록된 내용 전체를 응답을 보내주는것으로 로직 수정

## 📸 참고사항 및 스크린샷
ai 분석 요청시 슈파베이스에 자동 기록되며 그 결과를 반환함
<img width="680" height="220" alt="image" src="https://github.com/user-attachments/assets/3b9e815d-4df8-4a16-9f65-5fecf6121926" />