### PR TITLE
feat: 증분 동기화 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.conkeep"
         minSdk = 28
         targetSdk = 36
-        versionCode = 5
-        versionName = "0.0.3"
+        versionCode = 6
+        versionName = "0.0.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/conkeep/FcmService.kt
+++ b/app/src/main/java/com/conkeep/FcmService.kt
@@ -1,8 +1,15 @@
 package com.conkeep
 
 import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.conkeep.data.repository.coupon.UserRepository
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
+import com.conkeep.data.worker.CouponSyncWorker
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
@@ -11,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -28,6 +36,9 @@ class FcmService : FirebaseMessagingService() {
 
     @Inject
     lateinit var userPrefs: UserPreferencesRepository
+
+    @Inject
+    lateinit var workManager: WorkManager
 
     /**
      * 2. 서비스 전용 코루틴 스코프
@@ -82,7 +93,21 @@ class FcmService : FirebaseMessagingService() {
      */
     private fun handleSyncTrigger(timestamp: String?) {
         Log.d(TAG, "동기화 트리거 작동 시점: $timestamp")
-        // TODO: 여기서 WorkManager를 실행하여 실제 데이터를 Supabase에서 가져오는 로직을 수행해야 합니다.
+        val syncRequest =
+            OneTimeWorkRequestBuilder<CouponSyncWorker>()
+                .setConstraints(
+                    Constraints
+                        .Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+
+        workManager.enqueueUniqueWork(
+            "incremental_sync_coupon",
+            ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
+            syncRequest,
+        )
     }
 
     /**

--- a/app/src/main/java/com/conkeep/FcmService.kt
+++ b/app/src/main/java/com/conkeep/FcmService.kt
@@ -1,15 +1,10 @@
 package com.conkeep
 
 import android.util.Log
-import androidx.work.BackoffPolicy
-import androidx.work.Constraints
-import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
-import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.conkeep.data.repository.coupon.UserRepository
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
-import com.conkeep.data.worker.CouponSyncWorker
+import com.conkeep.data.sync.SyncManager
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -39,6 +33,9 @@ class FcmService : FirebaseMessagingService() {
 
     @Inject
     lateinit var workManager: WorkManager
+
+    @Inject
+    lateinit var syncManager: SyncManager
 
     /**
      * 2. 서비스 전용 코루틴 스코프
@@ -93,21 +90,7 @@ class FcmService : FirebaseMessagingService() {
      */
     private fun handleSyncTrigger(timestamp: String?) {
         Log.d(TAG, "동기화 트리거 작동 시점: $timestamp")
-        val syncRequest =
-            OneTimeWorkRequestBuilder<CouponSyncWorker>()
-                .setConstraints(
-                    Constraints
-                        .Builder()
-                        .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build(),
-                ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                .build()
-
-        workManager.enqueueUniqueWork(
-            "incremental_sync_coupon",
-            ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
-            syncRequest,
-        )
+        syncManager.enqueueCouponSync()
     }
 
     /**

--- a/app/src/main/java/com/conkeep/MainActivity.kt
+++ b/app/src/main/java/com/conkeep/MainActivity.kt
@@ -10,16 +10,11 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
-import androidx.work.BackoffPolicy
-import androidx.work.Constraints
-import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
-import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.conkeep.data.auth.SupabaseAuthManager
 import com.conkeep.data.repository.coupon.UserRepository
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
-import com.conkeep.data.worker.CouponSyncWorker
+import com.conkeep.data.sync.SyncManager
 import com.conkeep.navigation.NavigationRoot
 import com.conkeep.navigation.Route
 import com.conkeep.ui.theme.ConKeepTheme
@@ -31,7 +26,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -47,6 +41,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var workManager: WorkManager
+
+    @Inject
+    lateinit var syncManager: SyncManager
 
     private var isReady = mutableStateOf(false)
     private val initialRoute = mutableStateOf<Route?>(null)
@@ -89,26 +86,7 @@ class MainActivity : ComponentActivity() {
                         launch { handleFcmTokenUpdate() }
 
                         // 3. 쿠폰 증분 업데이트
-                        launch {
-                            val syncRequest =
-                                OneTimeWorkRequestBuilder<CouponSyncWorker>()
-                                    .setConstraints(
-                                        Constraints
-                                            .Builder()
-                                            .setRequiredNetworkType(NetworkType.CONNECTED)
-                                            .build(),
-                                    ).setBackoffCriteria(
-                                        BackoffPolicy.EXPONENTIAL,
-                                        30,
-                                        TimeUnit.SECONDS,
-                                    ).build()
-
-                            workManager.enqueueUniqueWork(
-                                "incremental_sync_coupon",
-                                ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
-                                syncRequest,
-                            )
-                        }
+                        launch { syncManager.enqueueCouponSync() }
 
                         // 최초 실행 시에만 초기 경로 설정
                         if (initialRoute.value == null) {

--- a/app/src/main/java/com/conkeep/MainActivity.kt
+++ b/app/src/main/java/com/conkeep/MainActivity.kt
@@ -10,9 +10,16 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.conkeep.data.auth.SupabaseAuthManager
 import com.conkeep.data.repository.coupon.UserRepository
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
+import com.conkeep.data.worker.CouponSyncWorker
 import com.conkeep.navigation.NavigationRoot
 import com.conkeep.navigation.Route
 import com.conkeep.ui.theme.ConKeepTheme
@@ -24,6 +31,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -36,6 +44,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var userPrefs: UserPreferencesRepository
+
+    @Inject
+    lateinit var workManager: WorkManager
 
     private var isReady = mutableStateOf(false)
     private val initialRoute = mutableStateOf<Route?>(null)
@@ -76,6 +87,28 @@ class MainActivity : ComponentActivity() {
 
                         // 2. FCM 토큰 업데이트 (변경된 경우에만)
                         launch { handleFcmTokenUpdate() }
+
+                        // 3. 쿠폰 증분 업데이트
+                        launch {
+                            val syncRequest =
+                                OneTimeWorkRequestBuilder<CouponSyncWorker>()
+                                    .setConstraints(
+                                        Constraints
+                                            .Builder()
+                                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                                            .build(),
+                                    ).setBackoffCriteria(
+                                        BackoffPolicy.EXPONENTIAL,
+                                        30,
+                                        TimeUnit.SECONDS,
+                                    ).build()
+
+                            workManager.enqueueUniqueWork(
+                                "incremental_sync_coupon",
+                                ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
+                                syncRequest,
+                            )
+                        }
 
                         // 최초 실행 시에만 초기 경로 설정
                         if (initialRoute.value == null) {

--- a/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
+++ b/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.Upsert
 import com.conkeep.data.local.dto.CouponCountResult
 import com.conkeep.data.local.entity.CouponEntity
 import com.conkeep.ui.feature.coupon.model.CouponCountSummary
@@ -154,6 +155,9 @@ interface CouponDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(coupon: CouponEntity)
+
+    @Upsert
+    suspend fun upsert(coupon: CouponEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(coupons: List<CouponEntity>)

--- a/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
+++ b/app/src/main/java/com/conkeep/data/local/dao/CouponDao.kt
@@ -153,6 +153,15 @@ interface CouponDao {
     @Query("SELECT * FROM coupons WHERE id = :id")
     suspend fun getCouponById(id: String): CouponEntity?
 
+    @Query("UPDATE coupons SET local_image_path = :localPath WHERE id = :couponId")
+    suspend fun updateLocalImagePath(
+        couponId: String,
+        localPath: String,
+    )
+
+    @Query("SELECT local_image_path FROM coupons WHERE id = :couponId")
+    suspend fun getLocalImagePath(couponId: String): String?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(coupon: CouponEntity)
 

--- a/app/src/main/java/com/conkeep/data/local/file/LocalFileManager.kt
+++ b/app/src/main/java/com/conkeep/data/local/file/LocalFileManager.kt
@@ -25,6 +25,7 @@ class LocalFileManager
         private val couponImageDir = File(context.filesDir, "coupon_images")
         private val tempImageDir = File(context.cacheDir, "temp_images")
         private val shareCacheDir = File(context.cacheDir, "share_tmp")
+        private val downloadTempDir = File(context.cacheDir, "download_temp")
 
         init {
             cleanupOldCache()
@@ -38,7 +39,7 @@ class LocalFileManager
                 val currentTime = System.currentTimeMillis()
                 val maxAge = 24 * 60 * 60 * 1000 // 24시간
 
-                listOf(tempImageDir, shareCacheDir).forEach { dir ->
+                listOf(tempImageDir, shareCacheDir, downloadTempDir).forEach { dir ->
                     dir.listFiles()?.forEach { file ->
                         if (currentTime - file.lastModified() > maxAge) {
                             file.delete()
@@ -49,6 +50,32 @@ class LocalFileManager
                 e.printStackTrace()
             }
         }
+
+        /**
+         * 다운로드된 이미지 바이트를 임시 파일로 저장합니다.
+         * @param bytes 이미지 바이트 데이터
+         * @param prefix 파일명 접두사 (예: "download_", "coupon_")
+         * @return 생성된 임시 파일, 실패 시 null
+         */
+        fun createTempFileFromBytes(
+            bytes: ByteArray,
+            prefix: String = "download",
+        ): File? =
+            try {
+                if (!downloadTempDir.exists()) downloadTempDir.mkdirs()
+
+                val tempFile =
+                    File(
+                        downloadTempDir,
+                        "${prefix}_${System.currentTimeMillis()}.webp",
+                    )
+
+                tempFile.writeBytes(bytes)
+                tempFile
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
 
         /**
          * Compressor 입력을 위해 Uri의 데이터를 캐시 디렉토리에 임시 파일로 복사합니다.

--- a/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeJobResponse.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/AiAnalyzeJobResponse.kt
@@ -1,13 +1,12 @@
 package com.conkeep.data.remote.dto
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AiCouponResponse(
-    val success: Boolean,
-    val data: CouponDto,
-    @SerialName("db_status") val dbStatus: String,
+data class AiAnalyzeJobResponse(
+    val success: Boolean = false,
+    val message: String = "",
+    val error: String? = null,
     val metadata: AiMetadata? = null,
 )
 

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -1,5 +1,6 @@
 package com.conkeep.data.repository.coupon
 
+import android.util.Log
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -15,6 +16,7 @@ import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.data.remote.dto.PresignedUrlResponse
 import com.conkeep.data.remote.dto.SupabaseCoupon
 import com.conkeep.data.remote.dto.toEntity
+import com.conkeep.data.repository.datastore.UserPreferencesRepository
 import com.conkeep.di.annotation.AuthClient
 import com.conkeep.di.annotation.R2UploadClient
 import com.conkeep.domain.model.Coupon
@@ -49,6 +51,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Clock
 
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -57,6 +60,7 @@ class CouponRepository
     constructor(
         private val supabase: SupabaseClient,
         private val couponDao: CouponDao,
+        private val userPrefs: UserPreferencesRepository,
         private val authManager: SupabaseAuthManager,
         @param:R2UploadClient private val r2Client: HttpClient,
         @param:AuthClient private val authClient: HttpClient,
@@ -209,22 +213,52 @@ class CouponRepository
                 Result.failure(Exception("분석 요청 중 알 수 없는 오류 발생: ${e.localizedMessage}"))
             }
 
-        suspend fun syncCouponFromServer(dto: CouponDto) {
-            val localCoupon = couponDao.getCouponById(dto.id)
+        suspend fun syncIncremental(): Result<List<CouponDto>> =
+            withContext(Dispatchers.IO) {
+                try {
+                    val lastSyncTime = userPrefs.lastSyncTime.first()
+                    val currentUserId =
+                        authManager.currentUserIdFlow.first()
+                            ?: return@withContext Result.failure(Exception("Not logged in"))
 
-            // 1. 충돌 방지: 사용자가 수동 수정을 시작했다면(isDirty) 서버 데이터로 덮어쓰지 않음
-            if (localCoupon?.isDirty == true) return
+                    val response =
+                        supabase.from("coupons").select {
+                            filter {
+                                gte("updated_at", lastSyncTime)
+                                eq("user_id", currentUserId)
+                                eq("is_deleted", false)
+                            }
+                        }
 
-            // 2. DTO -> Entity 변환 (로컬 경로 보존)
-            // localCoupon이 있다면 기존 localImagePath를 가져와서 합쳐줍니다.
-            val entity =
-                dto.toEntity(
-                    existingLocalPath = localCoupon?.localImagePath,
-                )
+                    val coupons = response.decodeList<CouponDto>()
 
-            // 3. 로컬 DB 갱신
-            couponDao.insert(entity)
-        }
+                    // upsert 로직
+                    coupons.forEach { dto ->
+                        val localCoupon = couponDao.getCouponById(dto.id)
+
+                        // 1. 충돌 방지: 사용자가 수동 수정을 시작했다면(isDirty) 서버 데이터로 덮어쓰지 않음
+                        if (localCoupon?.isDirty == true) return@forEach
+
+                        // 2. DTO -> Entity 변환 (로컬 경로 보존)
+                        // localCoupon이 있다면 기존 localImagePath를 가져와서 합쳐줍니다.
+                        val entity =
+                            dto.toEntity(
+                                existingLocalPath = localCoupon?.localImagePath,
+                            )
+
+                        // 3. 로컬 DB 갱신
+                        couponDao.upsert(entity)
+                        userPrefs.updateLastSyncTime(dto.updatedAt)
+                        // todo: 로컬 이미지가 비었다면 다운로드하는 워커 생성
+                    }
+
+                    userPrefs.updateLastSyncTime(Clock.System.now().toString())
+                    Result.success(coupons)
+                } catch (e: Exception) {
+                    Log.e("CouponRepository", "증분 동기화 실패", e)
+                    Result.failure(e)
+                }
+            }
 
         suspend fun updateStatus(
             id: String,

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -9,8 +9,8 @@ import com.conkeep.data.auth.SupabaseAuthManager
 import com.conkeep.data.local.dao.CouponDao
 import com.conkeep.data.mapper.toDomain
 import com.conkeep.data.mapper.toEntity
+import com.conkeep.data.remote.dto.AiAnalyzeJobResponse
 import com.conkeep.data.remote.dto.AiAnalyzeRequest
-import com.conkeep.data.remote.dto.AiCouponResponse
 import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.data.remote.dto.PresignedUrlResponse
 import com.conkeep.data.remote.dto.SupabaseCoupon
@@ -182,14 +182,14 @@ class CouponRepository
                 }
             }
 
-        suspend fun aiCouponRecognizing(
+        suspend fun requestAiAnalyzeJob(
             couponId: String,
             imageUrl: String,
             barcode: String?,
             createAt: String,
-        ): Result<CouponDto> =
+        ): Result<String> =
             try {
-                val response: AiCouponResponse =
+                val response: AiAnalyzeJobResponse =
                     authClient
                         .post("${BuildConfig.BASE_URL}/analyze") {
                             contentType(ContentType.Application.Json)
@@ -197,16 +197,16 @@ class CouponRepository
                         }.body()
 
                 if (response.success) {
-                    Result.success(response.data)
+                    Result.success(response.message)
                 } else {
-                    Result.failure(Exception("분석 실패 (서버 로직 에러)"))
+                    Result.failure(Exception("분석 요청 실패 (서버 로직 에러)"))
                 }
             } catch (e: ClientRequestException) {
-                Result.failure(Exception("분석 실패: ${e.response.status}"))
+                Result.failure(Exception("분석 요청 실패: ${e.response.status}"))
             } catch (e: TimeoutCancellationException) {
-                Result.failure(Exception("분석 시간 초과 (네트워크 상태를 확인하세요)"))
+                Result.failure(Exception("분석 요청 시간 초과 (네트워크 상태를 확인하세요)"))
             } catch (e: Exception) {
-                Result.failure(Exception("분석 중 알 수 없는 오류 발생: ${e.localizedMessage}"))
+                Result.failure(Exception("분석 요청 중 알 수 없는 오류 발생: ${e.localizedMessage}"))
             }
 
         suspend fun syncCouponFromServer(dto: CouponDto) {

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -324,32 +324,6 @@ class CouponRepository
                 ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
                 .build()
 
-        private fun enqueueCouponImageDownloadWorker(
-            couponId: String,
-            imageUrl: String,
-        ) {
-            val uploadRequest =
-                OneTimeWorkRequestBuilder<CouponImageDownloadWorker>()
-                    .setConstraints(
-                        Constraints
-                            .Builder()
-                            .setRequiredNetworkType(NetworkType.CONNECTED)
-                            .build(),
-                    ).setInputData(
-                        workDataOf(
-                            "COUPON_ID" to couponId,
-                            "IMAGE_URL" to imageUrl,
-                        ),
-                    ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                    .build()
-
-            workManager.enqueueUniqueWork(
-                "download_coupon_image_$couponId",
-                ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
-                uploadRequest,
-            )
-        }
-
         suspend fun downloadAndSaveImage(
             couponId: String,
             imageUrl: String,

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -5,9 +5,18 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
 import com.conkeep.BuildConfig
 import com.conkeep.data.auth.SupabaseAuthManager
 import com.conkeep.data.local.dao.CouponDao
+import com.conkeep.data.local.file.LocalFileManager
 import com.conkeep.data.mapper.toDomain
 import com.conkeep.data.mapper.toEntity
 import com.conkeep.data.remote.dto.AiAnalyzeJobResponse
@@ -17,6 +26,7 @@ import com.conkeep.data.remote.dto.PresignedUrlResponse
 import com.conkeep.data.remote.dto.SupabaseCoupon
 import com.conkeep.data.remote.dto.toEntity
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
+import com.conkeep.data.worker.CouponImageDownloadWorker
 import com.conkeep.di.annotation.AuthClient
 import com.conkeep.di.annotation.R2UploadClient
 import com.conkeep.domain.model.Coupon
@@ -33,12 +43,14 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.util.cio.readChannel
+import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
@@ -49,6 +61,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
@@ -62,6 +75,8 @@ class CouponRepository
         private val couponDao: CouponDao,
         private val userPrefs: UserPreferencesRepository,
         private val authManager: SupabaseAuthManager,
+        private val workManager: WorkManager,
+        private val localFileManager: LocalFileManager,
         @param:R2UploadClient private val r2Client: HttpClient,
         @param:AuthClient private val authClient: HttpClient,
     ) {
@@ -231,31 +246,141 @@ class CouponRepository
                         }
 
                     val coupons = response.decodeList<CouponDto>()
+                    val downloadQueue = mutableListOf<Pair<String, String>>()
 
-                    // upsert 로직
                     coupons.forEach { dto ->
                         val localCoupon = couponDao.getCouponById(dto.id)
 
-                        // 1. 충돌 방지: 사용자가 수동 수정을 시작했다면(isDirty) 서버 데이터로 덮어쓰지 않음
                         if (localCoupon?.isDirty == true) return@forEach
 
-                        // 2. DTO -> Entity 변환 (로컬 경로 보존)
-                        // localCoupon이 있다면 기존 localImagePath를 가져와서 합쳐줍니다.
                         val entity =
                             dto.toEntity(
                                 existingLocalPath = localCoupon?.localImagePath,
                             )
 
-                        // 3. 로컬 DB 갱신
                         couponDao.upsert(entity)
                         userPrefs.updateLastSyncTime(dto.updatedAt)
-                        // todo: 로컬 이미지가 비었다면 다운로드하는 워커 생성
+
+                        // 다운로드 큐에 추가만
+                        if (localCoupon == null && dto.imageUrl != null) {
+                            downloadQueue.add(entity.id to dto.imageUrl)
+                        }
                     }
+
+                    // 순차 실행으로 워커 체이닝
+                    enqueueImageDownloadChain(downloadQueue)
 
                     userPrefs.updateLastSyncTime(Clock.System.now().toString())
                     Result.success(coupons)
                 } catch (e: Exception) {
                     Log.e("CouponRepository", "증분 동기화 실패", e)
+                    Result.failure(e)
+                }
+            }
+
+        private fun enqueueImageDownloadChain(downloadQueue: List<Pair<String, String>>) {
+            if (downloadQueue.isEmpty()) return
+
+            Log.d("CouponRepository", "이미지 다운로드 큐: ${downloadQueue.size}개")
+
+            // 첫 번째 워커 생성
+            val firstRequest =
+                createDownloadWorkRequest(
+                    downloadQueue.first().first,
+                    downloadQueue.first().second,
+                )
+
+            // 나머지 워커들을 순차적으로 체이닝
+            var continuation =
+                workManager.beginUniqueWork(
+                    "download_coupon_images_chain",
+                    ExistingWorkPolicy.APPEND, // 기존 체인에 추가
+                    firstRequest,
+                )
+
+            downloadQueue.drop(1).forEach { (couponId, imageUrl) ->
+                val request = createDownloadWorkRequest(couponId, imageUrl)
+                continuation = continuation.then(request) // 순차 실행
+            }
+
+            continuation.enqueue()
+        }
+
+        private fun createDownloadWorkRequest(
+            couponId: String,
+            imageUrl: String,
+        ): OneTimeWorkRequest =
+            OneTimeWorkRequestBuilder<CouponImageDownloadWorker>()
+                .setConstraints(
+                    Constraints
+                        .Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                ).setInputData(
+                    workDataOf(
+                        "COUPON_ID" to couponId,
+                        "IMAGE_URL" to imageUrl,
+                    ),
+                ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+
+        private fun enqueueCouponImageDownloadWorker(
+            couponId: String,
+            imageUrl: String,
+        ) {
+            val uploadRequest =
+                OneTimeWorkRequestBuilder<CouponImageDownloadWorker>()
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).setInputData(
+                        workDataOf(
+                            "COUPON_ID" to couponId,
+                            "IMAGE_URL" to imageUrl,
+                        ),
+                    ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                    .build()
+
+            workManager.enqueueUniqueWork(
+                "download_coupon_image_$couponId",
+                ExistingWorkPolicy.KEEP, // 같은 이름의 워커가 이미 있으면 등록 안함
+                uploadRequest,
+            )
+        }
+
+        suspend fun downloadAndSaveImage(
+            couponId: String,
+            imageUrl: String,
+        ): Result<String> =
+            withContext(Dispatchers.IO) {
+                try {
+                    Log.d("CouponRepository", "이미지 다운로드 시작: $couponId")
+
+                    // 1. R2에서 다운로드
+                    val response = r2Client.get(imageUrl)
+                    val imageBytes = response.bodyAsChannel().toInputStream().readBytes()
+
+                    // 2. LocalFileManager로 임시 파일 생성
+                    val tempFile =
+                        localFileManager.createTempFileFromBytes(
+                            bytes = imageBytes,
+                            prefix = "coupon_$couponId",
+                        ) ?: return@withContext Result.failure(Exception("임시 파일 생성 실패"))
+
+                    // 3. LocalFileManager로 영구 저장
+                    val localPath =
+                        localFileManager.saveProcessedFile(tempFile)
+                            ?: return@withContext Result.failure(Exception("영구 저장 실패"))
+
+                    // 4. Room 업데이트
+                    couponDao.updateLocalImagePath(couponId, localPath)
+
+                    Log.d("CouponRepository", "이미지 다운로드 완료: $localPath")
+                    Result.success(localPath)
+                } catch (e: Exception) {
+                    Log.e("CouponRepository", "이미지 다운로드 실패: $couponId", e)
                     Result.failure(e)
                 }
             }

--- a/app/src/main/java/com/conkeep/data/repository/datastore/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/datastore/UserPreferencesRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Instant
 
 @Singleton
 class UserPreferencesRepository
@@ -24,14 +25,34 @@ class UserPreferencesRepository
         // 데이터 읽기 (Flow) - 데이터가 바뀔 때마다 자동으로 배출됩니다.
         val userId: Flow<String?> = dataStore.data.map { it[Keys.USER_ID] }
         val fcmToken: Flow<String?> = dataStore.data.map { it[Keys.FCM_TOKEN] }
-        val lastSyncTime: Flow<String?> = dataStore.data.map { it[Keys.LAST_SYNC_TIME] }
+        val lastSyncTime: Flow<String> =
+            dataStore.data.map { prefs ->
+                prefs[Keys.LAST_SYNC_TIME] ?: "1970-01-01T00:00:00Z"
+            }
 
         // 데이터 저장 (suspend) - 코루틴 안에서 실행되어 UI 스레드를 차단하지 않습니다.
         suspend fun updateUserId(id: String?) = dataStore.edit { it[Keys.USER_ID] = id ?: "" }
 
         suspend fun updateFcmToken(token: String?) = dataStore.edit { it[Keys.FCM_TOKEN] = token ?: "" }
 
-        suspend fun updateLastSyncTime(time: String) = dataStore.edit { it[Keys.LAST_SYNC_TIME] = time }
+        suspend fun updateLastSyncTime(time: String) =
+            dataStore.edit { prefs ->
+                val currentTime = prefs[Keys.LAST_SYNC_TIME] ?: "1970-01-01T00:00:00Z"
+
+                try {
+                    val newInstant = Instant.parse(time)
+                    val currentInstant = Instant.parse(currentTime)
+
+                    // 새 시간이 더 크면 업데이트
+                    if (newInstant > currentInstant) {
+                        prefs[Keys.LAST_SYNC_TIME] = time
+                    }
+                    // 작거나 같으면 업데이트 안 함 (기존값 유지)
+                } catch (e: Exception) {
+                    // 파싱 실패 시 업데이트 (안전장치)
+                    prefs[Keys.LAST_SYNC_TIME] = time
+                }
+            }
 
         // 로그아웃 시 전체 초기화
         suspend fun clearAll() = dataStore.edit { it.clear() }

--- a/app/src/main/java/com/conkeep/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/conkeep/data/sync/SyncManager.kt
@@ -1,0 +1,67 @@
+package com.conkeep.data.sync
+
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.conkeep.data.worker.CouponSyncWorker
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SyncManager
+    @Inject
+    constructor(
+        private val workManager: WorkManager,
+    ) {
+        /**
+         * 쿠폰 증분 동기화 워커를 등록합니다.
+         * 동일한 작업이 이미 실행 중이면 무시됩니다 (KEEP 정책).
+         */
+        fun enqueueCouponSync() {
+            Log.d(TAG, "쿠폰 증분 동기화 워커 등록")
+
+            val syncRequest =
+                OneTimeWorkRequestBuilder<CouponSyncWorker>()
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).setBackoffCriteria(
+                        BackoffPolicy.EXPONENTIAL,
+                        30,
+                        TimeUnit.SECONDS,
+                    ).build()
+
+            workManager.enqueueUniqueWork(
+                SYNC_WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                syncRequest,
+            )
+
+            Log.d(TAG, "워커 등록 완료: $SYNC_WORK_NAME")
+        }
+
+        /**
+         * 쿠폰 동기화 워커를 취소합니다.
+         */
+        fun cancelCouponSync() {
+            workManager.cancelUniqueWork(SYNC_WORK_NAME)
+            Log.d(TAG, "워커 취소: $SYNC_WORK_NAME")
+        }
+
+        /**
+         * 쿠폰 동기화 워커의 상태를 확인합니다.
+         */
+        fun getCouponSyncWorkInfo() = workManager.getWorkInfosForUniqueWorkLiveData(SYNC_WORK_NAME)
+
+        companion object {
+            private const val TAG = "SyncManager"
+            private const val SYNC_WORK_NAME = "incremental_sync_coupon"
+        }
+    }

--- a/app/src/main/java/com/conkeep/data/worker/CouponImageDownloadWorker.kt
+++ b/app/src/main/java/com/conkeep/data/worker/CouponImageDownloadWorker.kt
@@ -1,0 +1,72 @@
+package com.conkeep.data.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.conkeep.data.repository.coupon.CouponRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class CouponImageDownloadWorker
+    @AssistedInject
+    constructor(
+        @Assisted context: Context,
+        @Assisted workerParams: WorkerParameters,
+        private val couponRepository: CouponRepository,
+    ) : CoroutineWorker(context, workerParams) {
+        override suspend fun doWork(): Result {
+            // ⭐ 디버그 로그 추가!
+            Log.d(TAG, "=== Worker 시작 ===")
+            Log.d(TAG, "inputData keys: ${inputData.keyValueMap.keys}")
+            Log.d(TAG, "inputData values: ${inputData.keyValueMap}")
+
+            val couponId = inputData.getString("COUPON_ID")
+            val imageUrl = inputData.getString("IMAGE_URL")
+
+            Log.d(TAG, "couponId: $couponId")
+            Log.d(TAG, "imageUrl: $imageUrl")
+
+            if (couponId == null) {
+                Log.e(TAG, "COUPON_ID is null!")
+                return Result.failure()
+            }
+
+            if (imageUrl == null) {
+                Log.e(TAG, "IMAGE_URL is null!")
+                return Result.failure()
+            }
+
+            return try {
+                Log.d(TAG, "Repository 호출 시작: $couponId")
+                val result = couponRepository.downloadAndSaveImage(couponId, imageUrl)
+
+                result.fold(
+                    onSuccess = { localPath ->
+                        Log.d(TAG, "성공: $localPath")
+                        Result.success()
+                    },
+                    onFailure = { exception ->
+                        Log.e(TAG, "실패: ${exception.message}", exception)
+
+                        if (runAttemptCount < MAX_RETRY_COUNT) {
+                            Log.d(TAG, "재시도 $runAttemptCount/$MAX_RETRY_COUNT")
+                            Result.retry()
+                        } else {
+                            Result.failure()
+                        }
+                    },
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "예외 발생", e)
+                Result.failure()
+            }
+        }
+
+        companion object {
+            private const val TAG = "CouponImageDownloadWorker"
+            private const val MAX_RETRY_COUNT = 3
+        }
+    }

--- a/app/src/main/java/com/conkeep/data/worker/CouponImageUploadWorker.kt
+++ b/app/src/main/java/com/conkeep/data/worker/CouponImageUploadWorker.kt
@@ -6,7 +6,6 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.conkeep.data.local.entity.CouponStatus
-import com.conkeep.data.remote.dto.CouponDto
 import com.conkeep.data.repository.coupon.CouponRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -51,10 +50,11 @@ class CouponImageUploadWorker
                         mimeType,
                     ).getOrThrow()
 
-                // 3. AI 분석 요청 (직접 호출 -> fcm 증분 동기화로 변경시 삭제 필요)
-                couponRepository.updateStatus(couponId, CouponStatus.ANALYZING.name)
+                Log.d("CouponImageUploadWorker", "업로드 성공, 분석 시작")
+
+                // 3. AI 분석 요청
                 val aiResponse =
-                    couponRepository.aiCouponRecognizing(
+                    couponRepository.requestAiAnalyzeJob(
                         couponId,
                         urlResponse.imageUrl,
                         barcode,
@@ -62,14 +62,18 @@ class CouponImageUploadWorker
                     )
 
                 aiResponse.fold(
-                    onSuccess = { couponDto: CouponDto ->
-                        // AI 분석 성공 시 로컬 동기화
-                        couponRepository.syncCouponFromServer(couponDto.copy(status = CouponStatus.SUCCESS.name))
+                    onSuccess = { message: String ->
+                        Log.d("CouponImageUploadWorker", "AI 분석 요청 성공: $message")
+                        couponRepository.updateStatus(couponId, CouponStatus.ANALYZING.name)
                         Result.success()
                     },
-                    onFailure = {
-                        // 서버는 살았는데 분석만 실패한 경우 (분석중 연결 끊김 등, 개선 필요)
-                        couponRepository.updateStatus(couponId, CouponStatus.AI_FAILED.name)
+                    onFailure = { throwable ->
+                        Log.e(
+                            "CouponImageUploadWorker",
+                            "AI 분석 요청 실패: ${throwable.message}",
+                            throwable,
+                        )
+                        couponRepository.updateStatus(couponId, CouponStatus.UPLOAD_FAILED.name)
                         Result.failure()
                     },
                 )

--- a/app/src/main/java/com/conkeep/data/worker/CouponSyncWorker.kt
+++ b/app/src/main/java/com/conkeep/data/worker/CouponSyncWorker.kt
@@ -1,0 +1,81 @@
+package com.conkeep.data.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.conkeep.data.repository.coupon.CouponRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.ServerResponseException
+import kotlinx.io.IOException
+
+@HiltWorker
+class CouponSyncWorker
+    @AssistedInject
+    constructor(
+        @Assisted context: Context,
+        @Assisted workerParams: WorkerParameters,
+        private val couponRepository: CouponRepository,
+    ) : CoroutineWorker(context, workerParams) {
+        override suspend fun doWork(): Result =
+            try {
+                val syncResult = couponRepository.syncIncremental()
+                syncResult.fold(
+                    onSuccess = {
+                        Log.d("Worker", "증분 동기화 완료")
+                        Result.success()
+                    },
+                    onFailure = {
+                        Log.e("Worker", "증분 동기화 실패: ${it.message}")
+                        Result.retry()
+                    },
+                )
+            } catch (e: ClientRequestException) {
+                // 4xx
+                handleHttpError(e)
+            } catch (e: ServerResponseException) {
+                // 5xx
+                handleHttpError(e)
+            } catch (e: IOException) {
+                // 네트워크 연결 오류
+                Log.e("CouponSyncWorker", "네트워크 연결 오류: ${e.message}", e)
+                handleNetworkError()
+            } catch (e: Exception) {
+                Log.e("CouponSyncWorker", "예상치 못한 오류: ${e.message}", e)
+                if (runAttemptCount < 3) {
+                    Result.retry()
+                } else {
+                    Result.failure()
+                }
+            }
+
+        private fun handleHttpError(responseException: ResponseException): Result {
+            Log.w(
+                "CouponSyncWorker",
+                "state code: ${responseException.response.status.value}",
+            )
+
+            return when {
+                runAttemptCount < 5 -> {
+                    Result.retry()
+                }
+
+                else -> {
+                    Result.failure()
+                }
+            }
+        }
+
+        private fun handleNetworkError(): Result {
+            Log.d("CouponImageUploadWorker", "네트워크 연결 오류 재시도 $runAttemptCount/15")
+            return if (runAttemptCount < 15) {
+                Result.retry()
+            } else {
+                Result.failure()
+            }
+        }
+    }


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #58

## 📋 작업 내용

백엔드에서 이미지 업로드 성공 유무만 반환하도록 수정, (분석된 쿠폰 정보를 전달하지 않음)
쿠폰 이미지 업로드 완료시 바로 CouponImageUploadWorker 종료
백엔드에서 분석을 완료하면 fcm 발송만 하도록 수정
증분 동기화를 위한 슈파베이스 쿼리 구현 (특정 시점 이후의 쿠폰만 반환)
증분 동기화 로직 구현
앱 첫 기동시, fcm분석 완료 수신시 증분 동기화 수행

## 📸 참고사항 및 스크린샷
[Screen_recording_20260217_065324.webm](https://github.com/user-attachments/assets/1b85a3c5-e7dc-46eb-94d7-a0c52cf2439c)
