### PR TITLE
feat: 여러 기기에서의 푸시 알림 지원을 위한 FCM 토큰 관리 방식 개선

### DIFF
--- a/app/src/main/java/com/conkeep/FcmService.kt
+++ b/app/src/main/java/com/conkeep/FcmService.kt
@@ -107,8 +107,13 @@ class FcmService : FirebaseMessagingService() {
                         return@launch
                     }
 
+                // 캐시된 토큰 삭제
+                userPrefs.fcmToken.first()?.let { cachedToken ->
+                    userRepository.removeDevice(userId, cachedToken)
+                }
+
                 // 서버(Supabase)의 profiles 테이블에 내 주소를 저장합니다.
-                userRepository.updateFcmToken(userId, token)
+                userRepository.registerDevice(userId, token)
 
                 // 나중에 중복 요청을 방지하기 위해 로컬 캐시에도 저장해 둡니다.
                 userPrefs.updateFcmToken(token)

--- a/app/src/main/java/com/conkeep/MainActivity.kt
+++ b/app/src/main/java/com/conkeep/MainActivity.kt
@@ -159,9 +159,11 @@ class MainActivity : ComponentActivity() {
             // 4. 비교: 값이 없거나 다르다면 서버 업데이트 진행
             if (currentToken != cachedToken) {
                 Log.d("MainActivity", "FCM 토큰 변경 감지: 업데이트를 시작합니다.")
+                // 기존 토큰 삭제
+                userRepository.removeDevice(userId, cachedToken)
 
-                // 서버 전송
-                userRepository.updateFcmToken(userId, currentToken)
+                // 새 토큰 서버 전송
+                userRepository.registerDevice(userId, currentToken)
 
                 // 성공적으로 전송 완료 후 로컬 캐시 갱신
                 userPrefs.updateFcmToken(currentToken)

--- a/app/src/main/java/com/conkeep/data/remote/dto/DeviceDto.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/DeviceDto.kt
@@ -1,0 +1,14 @@
+// data/remote/dto/DeviceDto.kt
+package com.conkeep.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeviceDto(
+    val id: String? = null, // 생성 시 null (DB 자동 생성)
+    @SerialName("user_id") val userId: String,
+    @SerialName("fcm_token") val fcmToken: String,
+    @SerialName("last_used_at") val lastUsedAt: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+)

--- a/app/src/main/java/com/conkeep/data/repository/coupon/UserRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/UserRepository.kt
@@ -1,10 +1,13 @@
+// data/repository/coupon/UserRepository.kt
 package com.conkeep.data.repository.coupon
 
 import android.util.Log
+import com.conkeep.data.remote.dto.DeviceDto
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Clock
 
 @Singleton
 class UserRepository
@@ -12,16 +15,56 @@ class UserRepository
     constructor(
         private val supabase: SupabaseClient,
     ) {
-        suspend fun updateFcmToken(
+        /**
+         * FCM 토큰을 devices 테이블에 등록/갱신합니다.
+         * @param userId 사용자 ID (auth.users.id)
+         * @param fcmToken FCM 토큰
+         */
+        suspend fun registerDevice(
             userId: String,
-            token: String,
-        ) {
+            fcmToken: String,
+        ): Result<Unit> =
             try {
-                supabase
-                    .from("profiles")
-                    .upsert(mapOf("id" to userId, "fcm_token" to token))
+                val device =
+                    DeviceDto(
+                        userId = userId,
+                        fcmToken = fcmToken,
+                        lastUsedAt = Clock.System.now().toString(),
+                    )
+
+                // onConflict = "fcm_token" 으로 동일 토큰 재등록 방지
+                supabase.from("devices").upsert(device) {
+                    onConflict = "fcm_token"
+                }
+
+                Log.d("UserRepository", "디바이스 등록/갱신 완료: $fcmToken")
+                Result.success(Unit)
             } catch (e: Exception) {
-                Log.e("UserRepository", "FCM 토큰 슈파베이스 업데이트 실패", e)
+                Log.e("UserRepository", "디바이스 등록 실패", e)
+                Result.failure(e)
             }
-        }
+
+        /**
+         * 현재 로그인한 유저의 디바이스 FCM토큰을 삭제합니다
+         * @param userId 현재 로그인한 유저 ID
+         * @param fcmToken 삭제할 FCM 토큰
+         */
+        suspend fun removeDevice(
+            userId: String,
+            fcmToken: String,
+        ): Result<Unit> =
+            try {
+                supabase.from("devices").delete {
+                    filter {
+                        eq("user_id", userId)
+                        eq("fcm_token", fcmToken)
+                    }
+                }
+
+                Log.d("UserRepository", "디바이스 삭제 완료: $fcmToken")
+                Result.success(Unit)
+            } catch (e: Exception) {
+                Log.e("UserRepository", "디바이스 삭제 실패", e)
+                Result.failure(e)
+            }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #60

## 📋 작업 내용
슈파베이스 내 fcm토큰 저장 테이블 변경
멀티캐스트 방식으로 한 유저의 모든 기기에게 fcm를 보내도록 변경

## 📸 참고사항 및 스크린샷
