### PR TITLE
feat: 쿠폰 상세, 쿠폰 정보 수정 탑바 구현 

### DIFF
--- a/app/src/main/java/com/conkeep/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/conkeep/navigation/NavigationRoot.kt
@@ -16,6 +16,8 @@ import androidx.navigation3.ui.NavDisplay
 import com.conkeep.ui.feature.auth.LoginScreen
 import com.conkeep.ui.feature.coupon.detail.CouponDetailScreen
 import com.conkeep.ui.feature.coupon.detail.CouponDetailViewModel
+import com.conkeep.ui.feature.coupon.detail.CouponEditScreen
+import com.conkeep.ui.feature.coupon.edit.CouponEditViewModel
 import com.conkeep.ui.feature.coupon.image.CouponImageScreen
 import com.conkeep.ui.feature.coupon.image.CouponImageViewModel
 import com.conkeep.ui.feature.coupon.list.CouponScreen
@@ -104,6 +106,18 @@ private fun CouponNavigation(
                             factory.create(key.id)
                         }
                     CouponDetailScreen(
+                        id = key.id,
+                        backStack = couponBackStack,
+                        viewModel = viewModel,
+                    )
+                }
+
+                entry<Route.CouponEditScreen> { key ->
+                    val viewModel =
+                        hiltViewModel<CouponEditViewModel, CouponEditViewModel.Factory> { factory ->
+                            factory.create(key.id)
+                        }
+                    CouponEditScreen(
                         id = key.id,
                         backStack = couponBackStack,
                         viewModel = viewModel,

--- a/app/src/main/java/com/conkeep/navigation/Route.kt
+++ b/app/src/main/java/com/conkeep/navigation/Route.kt
@@ -20,6 +20,11 @@ sealed interface Route : NavKey {
     ) : Route
 
     @Serializable
+    data class CouponEditScreen(
+        val id: String,
+    ) : Route
+
+    @Serializable
     data class CouponImageScreen(
         val id: String,
     ) : Route

--- a/app/src/main/java/com/conkeep/ui/component/MainTopBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/MainTopBar.kt
@@ -2,7 +2,6 @@ package com.conkeep.ui.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,10 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,14 +26,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.conkeep.R
 import com.conkeep.ui.theme.ConKeepColors.brandPrimary
-import com.conkeep.ui.theme.ConKeepColors.brandSecondary
-import com.conkeep.ui.theme.ConKeepColors.textPrimary
 import com.conkeep.ui.theme.ConKeepTheme
 import com.conkeep.ui.theme.PretendardBold24
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopBar(
+fun MainTopBar(
     onClickSearchBarToggle: () -> Unit,
     onClickAdd: () -> Unit,
 ) {
@@ -79,40 +74,19 @@ fun TopBar(
 
                 Row {
                     // 오른쪽: 검색 토글 버튼
-                    Surface(
+                    TopBarButton(
+                        imageVector = searchImageVector,
+                        contentDescription = stringResource(R.string.topbar_search_toggle_description),
                         onClick = onClickSearchBarToggle,
-                        color = brandSecondary,
-                        shape = CircleShape,
-                        modifier = Modifier.size(45.dp),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = searchImageVector,
-                                contentDescription = stringResource(R.string.topbar_search_toggle_description),
-                                tint = textPrimary,
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                    }
-
+                    )
                     Spacer(Modifier.padding(end = 12.dp))
 
                     // 오른쪽: 추가 버튼
-                    Surface(
+                    TopBarButton(
+                        imageVector = plusImageVector,
+                        contentDescription = stringResource(R.string.topbar_add_coupon_description),
                         onClick = onClickAdd,
-                        color = brandSecondary,
-                        shape = CircleShape,
-                        modifier = Modifier.size(45.dp),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = plusImageVector,
-                                contentDescription = stringResource(R.string.topbar_add_coupon_description),
-                                tint = textPrimary,
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                    }
+                    )
                 }
             }
 
@@ -124,10 +98,10 @@ fun TopBar(
 
 @Preview(showBackground = true)
 @Composable
-fun TopBarPreview() {
+fun MainTopBarPreview() {
     ConKeepTheme {
         Surface {
-            TopBar(
+            MainTopBar(
                 onClickSearchBarToggle = {},
                 onClickAdd = {},
             )

--- a/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
@@ -1,0 +1,147 @@
+package com.conkeep.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.conkeep.R
+import com.conkeep.ui.theme.ConKeepColors.brandPrimary
+import com.conkeep.ui.theme.ConKeepTheme
+import com.conkeep.ui.theme.PretendardBold24
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MiddleTextTopBar(
+    middleText: String,
+    leftButtonConfig: TopBarButtonConfig? = null,
+    rightButtonConfig: TopBarButtonConfig? = null,
+) {
+    Surface(
+        color = brandPrimary,
+        shape = RoundedCornerShape(bottomStart = 30.dp, bottomEnd = 30.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .statusBarsPadding()
+                    .padding(horizontal = 24.dp, vertical = 0.dp),
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                        .height(64.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                    if (leftButtonConfig != null) {
+                        TopBarButton(
+                            imageVector = ImageVector.vectorResource(leftButtonConfig.iconResId),
+                            contentDescription = leftButtonConfig.contentDescription,
+                            onClick = leftButtonConfig.onClick,
+                        )
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = middleText,
+                        style = PretendardBold24,
+                    )
+                }
+
+                Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                    if (rightButtonConfig != null) {
+                        TopBarButton(
+                            imageVector = ImageVector.vectorResource(rightButtonConfig.iconResId),
+                            contentDescription = rightButtonConfig.contentDescription,
+                            onClick = rightButtonConfig.onClick,
+                        )
+                    }
+                }
+            }
+
+            // 하단 추가 여백
+            Spacer(modifier = Modifier.height(14.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MiddleTextTopBarPreview() {
+    ConKeepTheme {
+        Surface {
+            MiddleTextTopBar(
+                middleText = "프리뷰",
+                leftButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_back,
+                        contentDescription = "뒤로가기",
+                        onClick = {},
+                    ),
+                rightButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_back,
+                        contentDescription = "뒤로가기",
+                        onClick = {},
+                    ),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MiddleTextTopBarLeftNullPreview() {
+    ConKeepTheme {
+        Surface {
+            MiddleTextTopBar(
+                middleText = "프리뷰",
+                rightButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_back,
+                        contentDescription = "뒤로가기",
+                        onClick = {},
+                    ),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MiddleTextTopBarRightNullPreview() {
+    ConKeepTheme {
+        Surface {
+            MiddleTextTopBar(
+                middleText = "프리뷰",
+                leftButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_back,
+                        contentDescription = "뒤로가기",
+                        onClick = {},
+                    ),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/conkeep/ui/component/TopBarButton.kt
+++ b/app/src/main/java/com/conkeep/ui/component/TopBarButton.kt
@@ -1,0 +1,39 @@
+package com.conkeep.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.conkeep.ui.theme.ConKeepColors.brandSecondary
+import com.conkeep.ui.theme.ConKeepColors.textPrimary
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopBarButton(
+    imageVector: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        color = brandSecondary,
+        shape = CircleShape,
+        modifier = Modifier.size(45.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                tint = textPrimary,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/conkeep/ui/component/TopBarButtonConfig.kt
+++ b/app/src/main/java/com/conkeep/ui/component/TopBarButtonConfig.kt
@@ -1,0 +1,9 @@
+package com.conkeep.ui.component
+
+import androidx.annotation.DrawableRes
+
+data class TopBarButtonConfig(
+    @param:DrawableRes val iconResId: Int,
+    val contentDescription: String,
+    val onClick: () -> Unit,
+)

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/detail/CouponDetailScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/detail/CouponDetailScreen.kt
@@ -13,10 +13,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -24,7 +25,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import coil3.compose.AsyncImage
+import com.conkeep.R
+import com.conkeep.data.local.entity.CouponStatus
 import com.conkeep.navigation.Route
+import com.conkeep.ui.component.MiddleTextTopBar
+import com.conkeep.ui.component.TopBarButtonConfig
+import com.conkeep.ui.feature.coupon.model.CouponUiModel
+import kotlinx.datetime.LocalDate
 import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -35,21 +42,52 @@ fun CouponDetailScreen(
     viewModel: CouponDetailViewModel,
 ) {
     val coupon by viewModel.coupon.collectAsStateWithLifecycle()
-
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    CouponDetailScreenContent(
+        onBackClick = {
+            if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                backStack.removeLastOrNull()
+            }
+        },
+        onCouponEdit = {},
+        onImageClick = {
+            coupon?.id?.takeIf { it.isNotEmpty() }?.let { couponId ->
+                backStack.add(Route.CouponImageScreen(id = couponId))
+            }
+        },
+        onUseCoupon = { viewModel.useCoupon() },
+        coupon = coupon,
+        id = id,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CouponDetailScreenContent(
+    onBackClick: () -> Unit,
+    onCouponEdit: () -> Unit,
+    onImageClick: () -> Unit,
+    onUseCoupon: () -> Unit,
+    coupon: CouponUiModel?,
+    id: String,
+) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("쿠폰 상세") },
-                navigationIcon = {
-                    Button(onClick = {
-                        if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
-                            backStack.removeLastOrNull()
-                        }
-                    }) {
-                        Text("←")
-                    }
-                },
+            MiddleTextTopBar(
+                middleText = stringResource(R.string.coupon_detail_screen_title),
+                leftButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_back,
+                        contentDescription = stringResource(R.string.topbar_back_description),
+                        onClick = onBackClick,
+                    ),
+                rightButtonConfig =
+                    TopBarButtonConfig(
+                        iconResId = R.drawable.ic_edit,
+                        contentDescription = stringResource(R.string.coupon_edit_screen_title),
+                        onClick = onCouponEdit,
+                    ),
             )
         },
     ) { padding ->
@@ -61,6 +99,7 @@ fun CouponDetailScreen(
                     .padding(16.dp),
         ) {
             Log.d("CouponDetailScreen", "coupon: $coupon")
+
             AsyncImage(
                 model = File(coupon?.localImagePath ?: ""),
                 contentDescription = "쿠폰 이미지",
@@ -68,29 +107,25 @@ fun CouponDetailScreen(
                     Modifier
                         .fillMaxWidth()
                         .height(200.dp)
-                        .clickable(onClick = {
-                            coupon?.id?.takeIf { it.isNotEmpty() }?.let { id: String ->
-                                backStack.add(Route.CouponImageScreen(id = id))
-                            }
-                        }),
+                        .clickable(onClick = onImageClick),
             )
 
             Text("쿠폰 ID: $id", style = MaterialTheme.typography.titleLarge)
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            coupon.let { coupon ->
-                Text("번호: ${coupon?.number}")
-                Text("이름: ${coupon?.name}")
-                Text("유효기간: ${coupon?.expiryDate}")
-                Text("상태: ${coupon?.status?.name}")
-                Text("r2Url: ${coupon?.r2Url}")
+            coupon.let {
+                Text("번호: ${it?.number}")
+                Text("이름: ${it?.name}")
+                Text("유효기간: ${it?.expiryDate}")
+                Text("상태: ${it?.status?.name}")
+                Text("r2Url: ${it?.r2Url}")
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                if (coupon?.isUsed == false) {
+                if (it?.isUsed == false) {
                     Button(
-                        onClick = { viewModel.useCoupon() },
+                        onClick = onUseCoupon,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text("쿠폰 사용하기")
@@ -100,5 +135,32 @@ fun CouponDetailScreen(
                 }
             }
         }
+    }
+}
+
+private val fakeCoupon =
+    CouponUiModel(
+        id = "0",
+        number = "1234-5678-9012",
+        name = "스타벅스 아이스 아메리카노 T",
+        brand = "스타벅스",
+        expiryDate = LocalDate.parse("2025-12-31"),
+        isUsed = false,
+        isExpired = false,
+        status = CouponStatus.SUCCESS,
+    )
+
+@Preview(showBackground = true, name = "미사용 쿠폰")
+@Composable
+private fun CouponDetailScreenContentPreview() {
+    MaterialTheme {
+        CouponDetailScreenContent(
+            onBackClick = {},
+            onCouponEdit = {},
+            onImageClick = {},
+            onUseCoupon = {},
+            coupon = fakeCoupon,
+            id = "0",
+        )
     }
 }

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/edit/CouponEditScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/edit/CouponEditScreen.kt
@@ -1,14 +1,10 @@
 package com.conkeep.ui.feature.coupon.detail
 
-import android.util.Log
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -24,37 +20,32 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import coil3.compose.AsyncImage
 import com.conkeep.R
 import com.conkeep.data.local.entity.CouponStatus
 import com.conkeep.navigation.Route
 import com.conkeep.ui.component.MiddleTextTopBar
 import com.conkeep.ui.component.TopBarButtonConfig
+import com.conkeep.ui.feature.coupon.edit.CouponEditViewModel
 import com.conkeep.ui.feature.coupon.model.CouponUiModel
 import kotlinx.datetime.LocalDate
-import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CouponDetailScreen(
+fun CouponEditScreen(
     id: String,
     backStack: NavBackStack<NavKey>,
-    viewModel: CouponDetailViewModel,
+    viewModel: CouponEditViewModel,
 ) {
     val coupon by viewModel.coupon.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    CouponDetailScreenContent(
+    CouponEditScreenContent(
         onBackClick = {
             if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
                 backStack.removeLastOrNull()
             }
         },
-        onCouponEdit = {
-            coupon?.id?.takeIf { it.isNotEmpty() }?.let { couponId ->
-                backStack.add(Route.CouponEditScreen(id = couponId))
-            }
-        },
+        onCouponSave = {},
         onImageClick = {
             coupon?.id?.takeIf { it.isNotEmpty() }?.let { couponId ->
                 backStack.add(Route.CouponImageScreen(id = couponId))
@@ -68,9 +59,9 @@ fun CouponDetailScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun CouponDetailScreenContent(
+private fun CouponEditScreenContent(
     onBackClick: () -> Unit,
-    onCouponEdit: () -> Unit,
+    onCouponSave: () -> Unit,
     onImageClick: () -> Unit,
     onUseCoupon: () -> Unit,
     coupon: CouponUiModel?,
@@ -79,7 +70,7 @@ private fun CouponDetailScreenContent(
     Scaffold(
         topBar = {
             MiddleTextTopBar(
-                middleText = stringResource(R.string.coupon_detail_screen_title),
+                middleText = stringResource(R.string.coupon_edit_screen_title),
                 leftButtonConfig =
                     TopBarButtonConfig(
                         iconResId = R.drawable.ic_back,
@@ -88,9 +79,9 @@ private fun CouponDetailScreenContent(
                     ),
                 rightButtonConfig =
                     TopBarButtonConfig(
-                        iconResId = R.drawable.ic_edit,
-                        contentDescription = stringResource(R.string.coupon_edit_screen_title),
-                        onClick = onCouponEdit,
+                        iconResId = R.drawable.ic_save,
+                        contentDescription = stringResource(R.string.coupon_edit_screen_save_icon_description),
+                        onClick = onCouponSave,
                     ),
             )
         },
@@ -102,42 +93,9 @@ private fun CouponDetailScreenContent(
                     .padding(padding)
                     .padding(16.dp),
         ) {
-            Log.d("CouponDetailScreen", "coupon: $coupon")
-
-            AsyncImage(
-                model = File(coupon?.localImagePath ?: ""),
-                contentDescription = "쿠폰 이미지",
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(200.dp)
-                        .clickable(onClick = onImageClick),
-            )
-
-            Text("쿠폰 ID: $id", style = MaterialTheme.typography.titleLarge)
+            Text("Hello CouponEdit!")
 
             Spacer(modifier = Modifier.height(16.dp))
-
-            coupon.let {
-                Text("번호: ${it?.number}")
-                Text("이름: ${it?.name}")
-                Text("유효기간: ${it?.expiryDate}")
-                Text("상태: ${it?.status?.name}")
-                Text("r2Url: ${it?.r2Url}")
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                if (it?.isUsed == false) {
-                    Button(
-                        onClick = onUseCoupon,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("쿠폰 사용하기")
-                    }
-                } else {
-                    Text("이미 사용된 쿠폰입니다.")
-                }
-            }
         }
     }
 }
@@ -156,11 +114,11 @@ private val fakeCoupon =
 
 @Preview(showBackground = true, name = "미사용 쿠폰")
 @Composable
-private fun CouponDetailScreenContentPreview() {
+private fun CouponEditScreenContentPreview() {
     MaterialTheme {
-        CouponDetailScreenContent(
+        CouponEditScreenContent(
             onBackClick = {},
-            onCouponEdit = {},
+            onCouponSave = {},
             onImageClick = {},
             onUseCoupon = {},
             coupon = fakeCoupon,

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/edit/CouponEditViewModel.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/edit/CouponEditViewModel.kt
@@ -1,0 +1,53 @@
+package com.conkeep.ui.feature.coupon.edit
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.conkeep.data.repository.coupon.CouponRepository
+import com.conkeep.ui.feature.coupon.model.CouponUiModel
+import com.conkeep.ui.mapper.toUiModel
+import com.conkeep.util.TimeProvider
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel(assistedFactory = CouponEditViewModel.Factory::class)
+class CouponEditViewModel
+    @AssistedInject
+    constructor(
+        private val couponRepository: CouponRepository,
+        private val timeProvider: TimeProvider,
+        @Assisted private val couponId: String,
+    ) : ViewModel() {
+        @AssistedFactory
+        interface Factory {
+            fun create(couponId: String): CouponEditViewModel
+        }
+
+        val coupon: StateFlow<CouponUiModel?> =
+            couponRepository
+                .getCoupon(couponId)
+                .map { domainCoupon ->
+                    domainCoupon?.toUiModel(timeProvider.getToday())
+                }.stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5000),
+                    initialValue = null,
+                )
+
+        fun useCoupon() {
+            viewModelScope.launch {
+                couponRepository.markAsUsed(
+                    id = couponId,
+                    timestamp = System.currentTimeMillis(),
+                )
+            }
+        }
+    }

--- a/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/coupon/list/CouponListScreen.kt
@@ -45,7 +45,7 @@ import com.conkeep.data.local.entity.CouponStatus
 import com.conkeep.navigation.Route
 import com.conkeep.navigation.TabDestination
 import com.conkeep.ui.component.BottomNavigationBar
-import com.conkeep.ui.component.TopBar
+import com.conkeep.ui.component.MainTopBar
 import com.conkeep.ui.feature.coupon.list.component.CouponCard
 import com.conkeep.ui.feature.coupon.list.component.CouponFilterChipRow
 import com.conkeep.ui.feature.coupon.list.component.CouponSortRow
@@ -196,7 +196,7 @@ fun CouponScreenContent(
 
     Scaffold(
         topBar = {
-            TopBar(
+            MainTopBar(
                 onClickSearchBarToggle = {
                     isSearchBarShow = !isSearchBarShow
                 },

--- a/app/src/main/java/com/conkeep/ui/feature/setting/SettingScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/setting/SettingScreen.kt
@@ -16,7 +16,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.conkeep.navigation.TabDestination
 import com.conkeep.ui.component.BottomNavigationBar
-import com.conkeep.ui.component.TopBar
+import com.conkeep.ui.component.MainTopBar
 import com.conkeep.ui.theme.ConKeepTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,7 +36,7 @@ fun SettingScreen(
 fun SettingScreenContent(onTabChange: (TabDestination) -> Unit) {
     Scaffold(
         topBar = {
-            TopBar(
+            MainTopBar(
                 onClickSearchBarToggle = {
                 },
                 onClickAdd = {

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,4H6C4.895,4 4,4.895 4,6V18C4,19.104 4.895,20 6,20H18C19.105,20 20,19.104 20,18V12M18.414,8.414L19.5,7.328C20.281,6.547 20.281,5.281 19.5,4.5C18.719,3.719 17.453,3.719 16.671,4.5L15.586,5.586M18.414,8.414L12.378,14.45C12.099,14.73 11.743,14.92 11.356,14.998L8.414,15.586L9.003,12.644C9.08,12.257 9.27,11.901 9.55,11.622L15.586,5.586M18.414,8.414L15.586,5.586"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#002147"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,8 +61,9 @@
     <!--    쿠폰 상세 화면-->
     <string name="coupon_detail_screen_title">쿠폰 상세</string>
 
-    <!--    쿠폰 수정 화면-->
-    <string name="coupon_edit_screen_title">쿠폰 수정</string>
+    <!--    쿠폰 정보 수정 화면-->
+    <string name="coupon_edit_screen_title">쿠폰 정보 수정</string>
+    <string name="coupon_edit_screen_save_icon_description">쿠폰 저장</string>
 
     <!--    쿠폰 이미지 화면-->
     <string name="coupon_image_screen_image_description">쿠폰 이미지</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,12 @@
     <string name="coupon_count">%1$s 쿠폰 %2$d개</string>
     <string name="coupon_search_result">%1$s 쿠폰에서 %2$d개 찾음</string>
 
+    <!--    쿠폰 상세 화면-->
+    <string name="coupon_detail_screen_title">쿠폰 상세</string>
+
+    <!--    쿠폰 수정 화면-->
+    <string name="coupon_edit_screen_title">쿠폰 수정</string>
+
     <!--    쿠폰 이미지 화면-->
     <string name="coupon_image_screen_image_description">쿠폰 이미지</string>
     <string name="coupon_image_share_title">쿠폰 이미지 공유</string>


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #64 

## 📋 작업 내용
쿠폰 수정 페이지를 만들고 쿠폰 상세와 쿠폰 수정페이지의 탑바 UI 컴포저블을 적용했습니다

## 📸 참고사항 및 스크린샷
<img width="266" height="147" alt="image" src="https://github.com/user-attachments/assets/2141400a-2316-48a9-b917-7b3aec67ffa6" />
<img width="266" height="147" alt="image" src="https://github.com/user-attachments/assets/fc84f043-9ebd-458a-9873-f329f3749d2b" />
