### PR TITLE
bug: 일부 기기에서 네비게이션 바에 가려 로그인이 불가능한 버그 

### DIFF
--- a/app/src/main/java/com/conkeep/ui/component/BottomNavigationBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/BottomNavigationBar.kt
@@ -1,6 +1,10 @@
 package com.conkeep.ui.component
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -30,6 +34,7 @@ fun BottomNavigationBar(
     Column(modifier = modifier) {
         NavigationBar(
             containerColor = bgSurface,
+            windowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
         ) {
             TabDestination.items.forEach { tab ->
                 val isSelected = currentTab == tab

--- a/app/src/main/java/com/conkeep/ui/component/MainTopBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/MainTopBar.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
@@ -48,6 +53,7 @@ fun MainTopBar(
             modifier =
                 Modifier
                     .statusBarsPadding()
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
                     .padding(horizontal = 24.dp, vertical = 0.dp),
         ) {
             Row(

--- a/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
@@ -42,6 +47,7 @@ fun MiddleTextTopBar(
             modifier =
                 Modifier
                     .statusBarsPadding()
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
                     .padding(horizontal = 24.dp, vertical = 0.dp),
         ) {
             Row(


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #68 

## 📋 작업 내용
탑바와 바텀에 윈도우 인셋 패딩을 주어 엣지 투 엣지 모드에서 네비게이션 바와 겹치지 않도록 수정함

## 📸 참고사항 및 스크린샷
<img width="2424" height="1080" alt="image" src="https://github.com/user-attachments/assets/83184f13-7efa-40da-b208-6d5257fdb0ed" />
