### PR TITLE
refactor: TopBar 내 불필요한 Box size Modifier 제거

### DIFF
--- a/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
+++ b/app/src/main/java/com/conkeep/ui/component/MiddleTextTopBar.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -59,7 +58,7 @@ fun MiddleTextTopBar(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                Box(contentAlignment = Alignment.Center) {
                     if (leftButtonConfig != null) {
                         TopBarButton(
                             imageVector = ImageVector.vectorResource(leftButtonConfig.iconResId),
@@ -75,7 +74,7 @@ fun MiddleTextTopBar(
                     )
                 }
 
-                Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                Box(contentAlignment = Alignment.Center) {
                     if (rightButtonConfig != null) {
                         TopBarButton(
                             imageVector = ImageVector.vectorResource(rightButtonConfig.iconResId),


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #72 

## 📋 작업 내용
버튼의 크기를 40dp로 제한하던 modifier제거

## 📸 참고사항 및 스크린샷
