### PR TITLE
feat: HKDF를 이용해 유저별 쿠폰 핀, 이미지 링크 백엔드 암호화 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,11 @@ android {
             "SUPABASE_ANON_KEY",
             "\"${gradleLocalProperties(rootDir, providers).getProperty("SUPABASE_ANON_KEY")}\"",
         )
+        buildConfigField(
+            type = "String",
+            "COUPON_IMAGE_ENDPOINT",
+            "\"${gradleLocalProperties(rootDir, providers).getProperty("COUPON_IMAGE_ENDPOINT")}\"",
+        )
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.conkeep"
         minSdk = 28
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.1.1"
+        versionCode = 17
+        versionName = "0.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/conkeep/data/auth/SupabaseAuthManager.kt
+++ b/app/src/main/java/com/conkeep/data/auth/SupabaseAuthManager.kt
@@ -4,10 +4,12 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.provider.Settings
+import android.util.Base64
 import android.util.Log
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import com.conkeep.BuildConfig
+import com.conkeep.data.repository.auth.AuthRepository
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import io.github.jan.supabase.SupabaseClient
@@ -34,6 +36,7 @@ class SupabaseAuthManager
     @Inject
     constructor(
         supabase: SupabaseClient,
+        authRepository: AuthRepository,
     ) {
         val auth = supabase.auth
         private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -44,7 +47,7 @@ class SupabaseAuthManager
                 .map { status ->
                     status is SessionStatus.Authenticated
                 }.stateIn(
-                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+                    scope = scope,
                     started = SharingStarted.Eagerly, // 앱 시작부터 추적
                     initialValue = false,
                 )
@@ -70,6 +73,23 @@ class SupabaseAuthManager
             currentUserFlow
                 .map { it?.id }
                 .stateIn(scope, SharingStarted.Eagerly, auth.currentUserOrNull()?.id)
+
+        // 현재 사용자의 마스터키
+        val currentUserMasterKeyFlow: StateFlow<ByteArray?> =
+            auth.sessionStatus
+                .map { status ->
+                    when (status) {
+                        is SessionStatus.Authenticated -> {
+                            runCatching { authRepository.getMasterKey().masterKey }
+                                .onFailure { Log.e("SupabaseAuth", "마스터키 fetch 실패", it) }
+                                .onSuccess { Log.d("SupabaseAuth", "마스터키 fetch 성공") }
+                                .getOrNull()
+                                ?.let { Base64.decode(it, Base64.NO_WRAP) }
+                        }
+
+                        else -> null
+                    }
+                }.stateIn(scope, SharingStarted.Eagerly, null)
 
         suspend fun awaitInitialSession(): Boolean {
             auth.awaitInitialization()

--- a/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
+++ b/app/src/main/java/com/conkeep/data/mapper/CouponMapper.kt
@@ -84,7 +84,7 @@ fun Coupon.toEntity(): CouponEntity =
 
 fun List<Coupon>.toEntity(): List<CouponEntity> = map { it.toEntity() }
 
-fun CouponDto.toEntity(): CouponEntity {
+fun CouponDto.toEntity(imageUrl: String? = null): CouponEntity {
     // ISO 8601 문자열을 Long(Epoch Milli)으로 변환하는 헬퍼 함수
     fun String?.toEpochMilli(): Long =
         if (this.isNullOrBlank()) {
@@ -96,7 +96,7 @@ fun CouponDto.toEntity(): CouponEntity {
     return CouponEntity(
         id = this.id,
         userId = this.userId,
-        imageUrl = this.imageUrl,
+        imageUrl = imageUrl,
         productName = this.productName ?: "",
         brand = this.brand ?: "",
         couponPin = this.couponPin ?: "",

--- a/app/src/main/java/com/conkeep/data/remote/dto/CouponDTO.kt
+++ b/app/src/main/java/com/conkeep/data/remote/dto/CouponDTO.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 data class CouponDto(
     val id: String,
     @SerialName("user_id") val userId: String,
-    @SerialName("image_url") val imageUrl: String?,
+    @SerialName("image_timestamp") val imageTimestamp: Long?,
     @SerialName("product_name") val productName: String?,
     val brand: String?,
     @SerialName("coupon_pin") val couponPin: String?,

--- a/app/src/main/java/com/conkeep/data/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/auth/AuthRepository.kt
@@ -1,0 +1,25 @@
+package com.conkeep.data.repository.auth
+
+import com.conkeep.BuildConfig
+import com.conkeep.di.annotation.AuthClient
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.serialization.Serializable
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthRepository
+    @Inject
+    constructor(
+        @param:AuthClient private val authClient: HttpClient,
+    ) {
+        suspend fun getMasterKey(): MasterKeyResponse = authClient.get("${BuildConfig.BASE_URL}/master-key").body()
+    }
+
+@Serializable
+data class MasterKeyResponse(
+    val success: Boolean,
+    val masterKey: String,
+)

--- a/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
+++ b/app/src/main/java/com/conkeep/data/repository/coupon/CouponRepository.kt
@@ -20,6 +20,7 @@ import com.conkeep.data.remote.dto.SupabaseCoupon
 import com.conkeep.data.remote.dto.toDto
 import com.conkeep.data.remote.dto.toEntity
 import com.conkeep.data.repository.datastore.UserPreferencesRepository
+import com.conkeep.data.util.CouponCrypto
 import com.conkeep.di.annotation.AuthClient
 import com.conkeep.di.annotation.R2UploadClient
 import com.conkeep.domain.model.Coupon
@@ -255,10 +256,14 @@ class CouponRepository
             withContext(Dispatchers.IO) {
                 try {
                     val lastSyncTime = userPrefs.lastSyncTime.first()
-                    Log.d("CouponRepository", "증분 동기화 시작: $lastSyncTime")
                     val currentUserId =
                         authManager.currentUserIdFlow.first()
                             ?: return@withContext Result.failure(Exception("Not logged in"))
+
+                    // 마스터키 획득 (null이면 동기화 중단)
+                    val masterKey =
+                        authManager.currentUserMasterKeyFlow.first()
+                            ?: return@withContext Result.failure(Exception("마스터키 없음"))
 
                     val response =
                         supabase.from("coupons").select {
@@ -272,10 +277,24 @@ class CouponRepository
 
                     coupons.forEach { dto: CouponDto ->
                         val localCoupon = couponDao.getCouponById(dto.id)
-
                         if (localCoupon?.isDirty == true) return@forEach
 
-                        val entity = dto.toEntity()
+                        // 복호화 + imageUrl 파생
+                        val decryptedPin =
+                            dto.couponPin?.let {
+                                CouponCrypto.decryptPin(masterKey, it)
+                            }
+                        val imageKey = CouponCrypto.deriveImageKey(masterKey, dto.id)
+                        val imageUrl =
+                            "${BuildConfig.COUPON_IMAGE_ENDPOINT}$imageKey.webp" +
+                                dto.imageTimestamp?.let { "?t=$it" }.orEmpty()
+                        Log.d("CouponRepository", "imageUrl: $imageUrl")
+
+                        val entity =
+                            dto.toEntity(imageUrl).copy(
+                                couponPin = decryptedPin, // 복호화된 평문
+                                imageUrl = imageUrl, // 파생된 URL
+                            )
                         couponDao.upsert(entity)
                         couponDao.setIsClean(dto.id)
                         userPrefs.updateLastSyncTime(dto.updatedAt)

--- a/app/src/main/java/com/conkeep/data/util/CouponCrypto.kt
+++ b/app/src/main/java/com/conkeep/data/util/CouponCrypto.kt
@@ -1,0 +1,38 @@
+package com.conkeep.data.util
+
+import android.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+object CouponCrypto {
+    fun decryptPin(
+        masterKeyBytes: ByteArray,
+        cipherText: String,
+    ): String? =
+        runCatching {
+            val raw = Base64.decode(cipherText, Base64.NO_WRAP)
+            val iv = raw.sliceArray(0..11)
+            val data = raw.sliceArray(12..raw.lastIndex)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(masterKeyBytes, "AES"),
+                GCMParameterSpec(128, iv),
+            )
+            String(cipher.doFinal(data), Charsets.UTF_8)
+        }.getOrNull()
+
+    fun deriveImageKey(
+        masterKeyBytes: ByteArray,
+        couponId: String,
+    ): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(masterKeyBytes, "HmacSHA256"))
+        return Base64.encodeToString(
+            mac.doFinal(couponId.toByteArray()),
+            Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+        )
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #82 

## 📋 작업 내용
민감 쿠폰 정보 암호화
HKDF로 유저별 키 반환 api 구현
서버에 암호화된 쿠폰 핀, 이미지 링크를 저장하도록 변경
단말에서 복호화해서 room에 저장하도록 수정

## 📸 참고사항 및 스크린샷
<img width="815" height="267" alt="image" src="https://github.com/user-attachments/assets/c46fd1b3-be77-46d1-9f17-d74dd4138ac2" />
