### PR TITLE
feat: 알림 설정 화면 내 기기 권한 미허용 시 안내 오버레이 추가 및 권한 체크 로직 개선

### DIFF
--- a/app/src/main/java/com/conkeep/ui/feature/setting/SettingScreen.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/setting/SettingScreen.kt
@@ -3,6 +3,7 @@ package com.conkeep.ui.feature.setting
 import android.Manifest
 import android.app.Activity
 import android.app.AlarmManager
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -37,6 +38,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -83,32 +85,36 @@ fun SettingScreen(
     val activity = context as Activity
     val addCouponAlarmSettingSuccessMessage = "알림이 추가되었습니다."
     val addCouponAlarmSettingErrorMessage = "해당 알림은 이미 추가되어 있습니다."
-
     val removeCouponAlarmSettingSuccessMessage = "알림이 삭제되었습니다."
     val removeCouponAlarmSettingFailedMessage = "알림이 삭제되지 않았습니다."
-
     val logoutSettingMessage = "로그아웃 되었습니다."
 
-    val showSettingBottomSheet =
+    var showSettingBottomSheet by
         rememberSaveable(stateSaver = CouponAlarmSetting.Saver) {
             mutableStateOf(null)
         }
-    val showNotificationSettingsDialog = rememberSaveable { mutableStateOf(false) }
-    val showExactAlarmSettingsDialog = rememberSaveable { mutableStateOf(false) }
+    var showNotificationSettingsDialog by rememberSaveable { mutableStateOf(false) }
+    var showExactAlarmSettingsDialog by rememberSaveable { mutableStateOf(false) }
     var pendingExactAlarmCheck by rememberSaveable { mutableStateOf(false) }
-    val showLogoutDialog = rememberSaveable { mutableStateOf(false) }
+    var showLogoutDialog by rememberSaveable { mutableStateOf(false) }
+    var hasNotificationPermission by rememberSaveable {
+        mutableStateOf(checkNotificationPermission(context))
+    }
+    var pendingPermissionCheckOnly by rememberSaveable { mutableStateOf(false) }
 
-    val checkExactAlarmAndShowSheet = {
+    fun checkExactAlarmAndShowSheet() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val alarmManager = context.getSystemService(AlarmManager::class.java)
             if (alarmManager.canScheduleExactAlarms()) {
-                showSettingBottomSheet.value = CouponAlarmSetting(0, LocalTime(9, 0))
+                if (pendingPermissionCheckOnly) return
+                showSettingBottomSheet = CouponAlarmSetting(0, LocalTime(9, 0))
             } else {
-                showExactAlarmSettingsDialog.value = true
+                showExactAlarmSettingsDialog = true
             }
         } else {
-            // Android 11 이하: 권한 불필요
-            showSettingBottomSheet.value = CouponAlarmSetting(0, LocalTime(9, 0))
+            // Android 11 이하
+            if (pendingPermissionCheckOnly) return
+            showSettingBottomSheet = CouponAlarmSetting(0, LocalTime(9, 0))
         }
     }
 
@@ -118,50 +124,85 @@ fun SettingScreen(
             contract = ActivityResultContracts.RequestPermission(),
         ) { isGranted ->
             if (isGranted) {
-                checkExactAlarmAndShowSheet() // 알림 권한 허용 → 정확한 알람 권한 체크로 이동
+                checkExactAlarmAndShowSheet()
             } else {
                 if (!ActivityCompat.shouldShowRequestPermissionRationale(
                         activity,
                         Manifest.permission.POST_NOTIFICATIONS,
                     )
                 ) {
-                    showNotificationSettingsDialog.value = true
+                    showNotificationSettingsDialog = true
                 } else {
+                    showNotificationSettingsDialog = true
                     Toast.makeText(context, "알림 권한이 거부되었습니다.", Toast.LENGTH_SHORT).show()
                 }
             }
         }
 
-    // 2. 권한 체크 및 실행 로직을 별도 함수로 분리
-    val checkPermissionAndShowSheet = {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val permissionStatus =
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.POST_NOTIFICATIONS,
-                )
-            if (permissionStatus == PackageManager.PERMISSION_GRANTED) {
-                checkExactAlarmAndShowSheet() // 알림 이미 있으면 바로 정확한 알람 및 리마인더 체크로
-            } else {
-                permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
-        } else {
+    // 권한 체크 및 실행 로직을 별도 함수로 분리
+    fun checkPermissionAndShowSheet(isPermissionCheckOnly: Boolean = false) {
+        pendingPermissionCheckOnly = isPermissionCheckOnly
+
+        // 모든 안드로이드 버전 호환 알림 켜짐 여부 확인
+        val areNotificationsEnabled =
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+        if (areNotificationsEnabled) {
+            // 알림이 켜져 있으면, 정확한 알람(Exact Alarm) 권한 체크로 넘어감
             checkExactAlarmAndShowSheet()
+        } else {
+            // 알림이 꺼져 있는 경우 분기 처리
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                // Android 13 이상: 아직 권한을 요청할 수 있는 상태인지 확인
+                val permissionStatus =
+                    ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.POST_NOTIFICATIONS,
+                    )
+
+                if (permissionStatus == PackageManager.PERMISSION_GRANTED) {
+                    // 권한은 있으나 시스템 설정에서 꺼버린 경우
+                    showNotificationSettingsDialog = true
+                } else if (ActivityCompat.shouldShowRequestPermissionRationale(
+                        activity,
+                        Manifest.permission.POST_NOTIFICATIONS,
+                    )
+                ) {
+                    // 사용자가 명시적으로 거부했던 경우 -> 설정 다이얼로그
+                    showNotificationSettingsDialog = true
+                } else {
+                    // 아직 권한을 요청한 적이 없는 경우 -> 시스템 권한 팝업 띄우기
+                    permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            } else {
+                // Android 12 이하: 런타임 팝업이 없으므로 무조건 설정 앱으로 유도하는 다이얼로그 띄움
+                showNotificationSettingsDialog = true
+            }
         }
     }
 
-    DisposableEffect(
-        LocalLifecycleOwner.current,
-    ) {
+    DisposableEffect(LocalLifecycleOwner.current) {
         val observer =
             LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_RESUME && pendingExactAlarmCheck) {
-                    pendingExactAlarmCheck = false
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        val alarmManager =
-                            context.getSystemService(AlarmManager::class.java)
-                        if (alarmManager.canScheduleExactAlarms()) {
-                            showSettingBottomSheet.value = CouponAlarmSetting(0, LocalTime(9, 0))
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    // 앱에 돌아올 때마다 권한 상태 갱신
+                    hasNotificationPermission = checkNotificationPermission(context)
+
+                    // 기존 ExactAlarm 체크 로직
+                    if (pendingExactAlarmCheck) {
+                        pendingExactAlarmCheck = false
+                        if (pendingPermissionCheckOnly) {
+                            pendingPermissionCheckOnly = false
+                            return@LifecycleEventObserver
+                        }
+
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            val alarmManager = context.getSystemService(AlarmManager::class.java)
+                            if (alarmManager.canScheduleExactAlarms()) {
+                                showSettingBottomSheet = CouponAlarmSetting(0, LocalTime(9, 0))
+                            }
+                        } else {
+                            showSettingBottomSheet = CouponAlarmSetting(0, LocalTime(9, 0))
                         }
                     }
                 }
@@ -224,20 +265,22 @@ fun SettingScreen(
         addCouponAlarmSetting = viewModel::addCouponAlarmSetting,
         removeCouponAlarmSetting = viewModel::removeCouponAlarmSetting,
         checkPermissionAndShowSheet = { checkPermissionAndShowSheet() },
+        checkPermissionOnly = { checkPermissionAndShowSheet(true) },
+        isPermissionOverlyEnabled = hasNotificationPermission.not() && couponAlarmSettings.isNotEmpty(),
         updatePendingExactAlarmCheck = { pendingExactAlarmCheck = it },
-        showNotificationSettingsDialog = showNotificationSettingsDialog.value,
-        onDismissNotificationDialog = { showNotificationSettingsDialog.value = false },
-        showExactAlarmSettingsDialog = showExactAlarmSettingsDialog.value,
-        onDismissExactAlarmDialog = { showExactAlarmSettingsDialog.value = false },
-        showSettingBottomSheet = showSettingBottomSheet.value,
+        showNotificationSettingsDialog = showNotificationSettingsDialog,
+        onDismissNotificationDialog = { showNotificationSettingsDialog = false },
+        showExactAlarmSettingsDialog = showExactAlarmSettingsDialog,
+        onDismissExactAlarmDialog = { showExactAlarmSettingsDialog = false },
+        showSettingBottomSheet = showSettingBottomSheet,
         moveDeleteAccountScreen = moveDeleteAccountScreen,
-        onUpdateBottomSheet = { showSettingBottomSheet.value = it },
+        onUpdateBottomSheet = { showSettingBottomSheet = it },
         accountInfo = accountInfo,
-        showLogoutDialog = showLogoutDialog.value,
-        onShowLogoutDialog = { showLogoutDialog.value = true },
+        showLogoutDialog = showLogoutDialog,
+        onShowLogoutDialog = { showLogoutDialog = true },
         onLogout = viewModel::logout,
         onDismissLogoutDialog = {
-            showLogoutDialog.value = false
+            showLogoutDialog = false
         },
     )
 }
@@ -253,6 +296,8 @@ fun SettingScreenContent(
     removeCouponAlarmSetting: (CouponAlarmSetting) -> Unit,
     // 권한 관련 액션
     checkPermissionAndShowSheet: () -> Unit,
+    checkPermissionOnly: () -> Unit,
+    isPermissionOverlyEnabled: Boolean,
     updatePendingExactAlarmCheck: (Boolean) -> Unit,
     // UI 상태 제어 (State & 이벤트를 쌍으로 전달)
     showNotificationSettingsDialog: Boolean,
@@ -388,9 +433,17 @@ fun SettingScreenContent(
                         removeCouponAlarmSetting(it)
                     },
                     couponAlarmSettings = couponAlarmSettings,
+                    onOverlayClick = {
+                        checkPermissionOnly()
+                    },
+                    isOverlayEnabled = isPermissionOverlyEnabled,
                 )
                 NormalSetting(onClickNotice)
-                AccountSetting(onShowLogoutDialog, moveDeleteAccountScreen, accountInfo = accountInfo)
+                AccountSetting(
+                    onShowLogoutDialog,
+                    moveDeleteAccountScreen,
+                    accountInfo = accountInfo,
+                )
                 Text(
                     "현재 버전 v${BuildConfig.VERSION_NAME}",
                     style = PretendardMedium12,
@@ -399,6 +452,24 @@ fun SettingScreenContent(
             }
         }
     }
+}
+
+private fun checkNotificationPermission(context: Context): Boolean {
+    // - Android 13 이상: POST_NOTIFICATIONS 권한 허용 여부 및 채널 차단 여부까지 종합 확인
+    // - Android 12 이하: 시스템 설정에서 해당 앱의 알림을 수동으로 껐는지 확인
+    val hasPostNotifications = NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+    // 정확한 알람(리마인더) 권한 체크 (Android 12 / API 31 이상)
+    val hasExactAlarm =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = context.getSystemService(android.app.AlarmManager::class.java)
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true // Android 11 이하는 자동 허용됨
+        }
+
+    // 두 가지 권한을 모두 가지고 있어야 true 반환
+    return hasPostNotifications && hasExactAlarm
 }
 
 @Preview(showBackground = true)
@@ -412,6 +483,8 @@ private fun SettingScreenContentPreview() {
             addCouponAlarmSetting = {},
             removeCouponAlarmSetting = {},
             checkPermissionAndShowSheet = {},
+            checkPermissionOnly = {},
+            isPermissionOverlyEnabled = false,
             updatePendingExactAlarmCheck = {},
             showNotificationSettingsDialog = false,
             onDismissNotificationDialog = {},
@@ -444,6 +517,8 @@ private fun SettingScreenContentPermissionDialogPreview() {
             addCouponAlarmSetting = {},
             removeCouponAlarmSetting = {},
             checkPermissionAndShowSheet = {},
+            checkPermissionOnly = {},
+            isPermissionOverlyEnabled = true,
             updatePendingExactAlarmCheck = {},
             showNotificationSettingsDialog = true,
             onDismissNotificationDialog = {},

--- a/app/src/main/java/com/conkeep/ui/feature/setting/notification/NotificationSetting.kt
+++ b/app/src/main/java/com/conkeep/ui/feature/setting/notification/NotificationSetting.kt
@@ -2,6 +2,7 @@ package com.conkeep.ui.feature.setting.notification
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,6 +36,7 @@ import com.conkeep.ui.theme.ConKeepColors.textPrimary
 import com.conkeep.ui.theme.ConKeepColors.textSecondary
 import com.conkeep.ui.theme.ConKeepTheme
 import com.conkeep.ui.theme.PretendardMedium16
+import com.conkeep.ui.theme.PretendardMedium20
 import com.conkeep.ui.theme.PretendardSemibold20
 import kotlinx.datetime.LocalTime
 
@@ -42,8 +45,10 @@ import kotlinx.datetime.LocalTime
 fun NotificationSetting(
     onAddNewAlarmClick: () -> Unit,
     onTrashClick: (CouponAlarmSetting) -> Unit,
+    onOverlayClick: () -> Unit,
     modifier: Modifier = Modifier,
     couponAlarmSettings: Set<CouponAlarmSetting> = emptySet(),
+    isOverlayEnabled: Boolean = false,
 ) {
     Column(
         horizontalAlignment = Alignment.Start,
@@ -54,80 +59,120 @@ fun NotificationSetting(
             style = PretendardSemibold20,
             color = textPrimary,
         )
-        Column(
+        Box(
             modifier =
                 modifier
                     .fillMaxWidth()
                     .background(color = bgSurface, shape = RoundedCornerShape(12.dp))
-                    .padding(horizontal = 20.dp, vertical = 20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(18.dp),
+                    .clip(RoundedCornerShape(12.dp)),
         ) {
-            when {
-                couponAlarmSettings.isEmpty() -> {
-                    Surface(
-                        modifier =
-                            modifier
-                                .fillMaxWidth()
-                                .height(36.dp),
-                    ) {
-                        Box(
+            Column(
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .background(color = bgSurface)
+                        .padding(horizontal = 20.dp, vertical = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(18.dp),
+            ) {
+                when {
+                    couponAlarmSettings.isEmpty() -> {
+                        Surface(
                             modifier =
-                                Modifier
-                                    .wrapContentHeight(),
-                            contentAlignment = Alignment.Center,
+                                modifier
+                                    .fillMaxWidth()
+                                    .height(36.dp),
                         ) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .wrapContentHeight(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = "현재 알림을 받고 있지 않아요",
+                                    style = PretendardMedium16,
+                                    color = textSecondary,
+                                )
+                            }
+                        }
+                    }
+
+                    else ->
+                        couponAlarmSettings
+                            .sortedWith(compareBy({ it.daysBefore }, { it.targetTime }))
+                            .forEach { couponAlarmSetting ->
+                                NotificationItem(
+                                    couponAlarmSetting = couponAlarmSetting,
+                                    onTrashClick = onTrashClick,
+                                )
+                            }
+                }
+
+                Surface(
+                    modifier =
+                        modifier
+                            .fillMaxWidth()
+                            .height(36.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    border =
+                        BorderStroke(
+                            0.6.dp,
+                            borderSubtle,
+                        ),
+                    onClick = onAddNewAlarmClick,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .wrapContentHeight(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_plus_small),
+                                contentDescription = "새 알림 추가",
+                                tint = textSecondary,
+                            )
                             Text(
-                                text = "현재 알림을 받고 있지 않아요",
+                                text = "새 알림 추가",
                                 style = PretendardMedium16,
                                 color = textSecondary,
                             )
                         }
                     }
                 }
-
-                else ->
-                    couponAlarmSettings
-                        .sortedWith(compareBy({ it.daysBefore }, { it.targetTime }))
-                        .forEach { couponAlarmSetting ->
-                            NotificationItem(
-                                couponAlarmSetting = couponAlarmSetting,
-                                onTrashClick = onTrashClick,
-                            )
-                        }
             }
-
-            Surface(
-                modifier =
-                    modifier
-                        .fillMaxWidth()
-                        .height(36.dp),
-                shape = RoundedCornerShape(12.dp),
-                border =
-                    BorderStroke(
-                        0.6.dp,
-                        borderSubtle,
-                    ),
-                onClick = onAddNewAlarmClick,
-            ) {
+            // 덮어씌우는 반투명 검은색 오버레이
+            if (isOverlayEnabled) {
                 Box(
                     modifier =
                         Modifier
-                            .wrapContentHeight(),
-                    contentAlignment = Alignment.Center,
+                            .matchParentSize()
+                            .background(
+                                androidx.compose.ui.graphics.Color.Black
+                                    .copy(alpha = 0.7f),
+                            ).clickable(onClick = onOverlayClick),
+                    contentAlignment = Alignment.Center, // 문구를 정중앙에 배치
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_plus_small),
-                            contentDescription = "새 알림 추가",
-                            tint = textSecondary,
-                        )
                         Text(
-                            text = "새 알림 추가",
-                            style = PretendardMedium16,
-                            color = textSecondary,
+                            text = "알림이 설정되어 있지만\n기기 알림 권한이 꺼져 있어요.",
+                            style = PretendardMedium20,
+                            color = androidx.compose.ui.graphics.Color.White,
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        )
+
+                        Text(
+                            text = "터치하여 권한 설정하기",
+                            style = PretendardMedium20, // 필요하다면 밑줄 들어간 스타일 사용
+                            color = brandSecondary, // 브랜드 강조색 사용
+                            textDecoration = androidx.compose.ui.text.style.TextDecoration.Underline,
                         )
                     }
                 }
@@ -247,6 +292,7 @@ fun NotificationSettingEmptyPreview() {
                 onAddNewAlarmClick = {},
                 couponAlarmSettings = emptySet(),
                 onTrashClick = {},
+                onOverlayClick = {},
             )
         }
     }
@@ -265,6 +311,26 @@ fun NotificationSettingPreview() {
                         CouponAlarmSetting(1, LocalTime(9, 0)),
                     ),
                 onTrashClick = {},
+                onOverlayClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NotificationSettingRevokePermissionPreview() {
+    ConKeepTheme {
+        Surface(color = brandSecondary) {
+            NotificationSetting(
+                onAddNewAlarmClick = {},
+                couponAlarmSettings =
+                    setOf(
+                        CouponAlarmSetting(0, LocalTime(12, 0)),
+                    ),
+                onTrashClick = {},
+                onOverlayClick = {},
+                isOverlayEnabled = true,
             )
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #92 

## 📋 작업 내용
알람 리마인더 권한 회수 감지시 설정 화면에 알림, 권한 허용 유도
안드로이드 12 이하에서 알림 권한 회수시에 알림 추가가 가능하던 문제도 해결

## 📸 참고사항 및 스크린샷
<img width="295" height="394" alt="image" src="https://github.com/user-attachments/assets/cb36958a-43c7-4590-a3d8-a2e351aa2b96" />